### PR TITLE
Fix/flow discovery

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -137,7 +137,7 @@ Capture the correction first, then resume the current task.
 
 ## Release Workflow
 
-`/release v[X.Y.Z]` — full release sequence; see `.claude/skills/release.md`. **NEVER run `git push` yourself** — always hand the git commands to the project owner.
+`/release v[X.Y.Z]` — full release sequence; see `.claude/commands/release.md`. **NEVER run `git push` yourself** — always hand the git commands to the project owner.
 
 ## Communication Style
 

--- a/.claude/commands/pre-commit.md
+++ b/.claude/commands/pre-commit.md
@@ -1,14 +1,11 @@
-## Pre-Commit Security Check
-
-Files in scope: $ARGUMENTS
-(If no files specified, ask the project owner which files are being committed.)
+## Pre-Commit Gate
 
 Type-check, build, lint, and format have already run inside the
-developer agent after each unit. This gate handles security only.
+developer agent after each unit. This gate handles code review and security.
 
-## Step 1: Determine changed file scope
+## Step 1: Determine changed file scope once
 
-If $ARGUMENTS were provided, use that list as scope. Otherwise, determine scope from git:
+If $ARGUMENTS were provided, use that list as scope. Otherwise, determine scope from git **once** — this result will be passed to both reviewer and security-auditor:
 
 1. **Try:** `git diff origin/<current-branch>...HEAD --name-only`
    - If this succeeds and returns files, use that list.
@@ -22,7 +19,20 @@ If $ARGUMENTS were provided, use that list as scope. Otherwise, determine scope 
    Fall back to a full scan.
    - Note in the output: "Could not determine diff scope — running full scan."
 
-## Step 2: Security audit (changed files only)
+Store this file list for use in Steps 2 and 3.
+
+## Step 2: Code review (changed files only)
+
+Invoke @reviewer with this instruction prepended to the agent prompt:
+
+"Scoped run — review only these changed files: <file list from Step 1>
+Do not review files outside this scope."
+
+The reviewer performs read-only TypeScript, React, Fluent UI v9, and code quality checks on the determined scope files only.
+
+If any major issue found: report and ask project owner whether to proceed.
+
+## Step 3: Security audit (changed files only)
 
 Invoke @security-auditor with this instruction prepended to the agent prompt:
 
@@ -43,6 +53,7 @@ MEDIUM or LOW: report and ask project owner whether to proceed.
 
 ```
 Pre-commit complete.
+Code review ✅/❌/⚠️
 Security audit ✅/❌/⚠️
 Verdict: CLEAR TO COMMIT ✅ / BLOCKED ❌
 ```

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,4 +1,7 @@
-/agent orchestrator
+---
+allowed-tools: Task, Read, Bash
+description: Run the full PPSB release sequence. Invoke when the project owner says things like "ready for release", "run release", "trigger release", "cut a release", "prepare a release", or "release vX.Y.Z".
+---
 
 Release sequence for Power Platform Solution Blueprint (PPSB).
 Run every step in order. Do not skip steps. Do not proceed past a failed step.
@@ -73,7 +76,7 @@ Invoke the **developer** agent with these exact tasks, in this exact order:
 1. `pnpm typecheck` — must pass with zero errors. Stop if any errors.
 2. `pnpm build` — must complete successfully. Stop if it fails.
 
-**Progress:** Step 4 complete ✅ — Typecheck passed. Build succeeded. / ❌ Step 4 failed — [typecheck/build error]. Release halted.
+**Progress:** Step 4 complete ✅ — Typecheck passed. Build succeeded. / ❌ Step 4 failed — [error]. Release halted.
 
 ---
 
@@ -83,15 +86,18 @@ Confirm all four steps passed, then print the following — do not run any of th
 
 ```
 Release complete.
-Code review ✅
-Security audit ✅
-Version bump ✅
-pnpm typecheck ✅
-pnpm build ✅
-Verdict: READY TO PUBLISH ✅
+Code review ✅/❌
+Security audit ✅/❌/⚠️
+Version bump ✅/❌
+Documentation updated ✅/❌
+Typecheck ✅/❌
+Build ✅/❌
+Verdict: READY TO PUBLISH ✅ / BLOCKED ❌
+```
 
-Run these commands to publish:
+Then print the git commands for manual execution only if verdict is READY TO PUBLISH:
 
+```
 git add package.json CHANGELOG.md README.md npm-shrinkwrap.json
 git commit -m "chore: release v[VERSION]"
 git tag v[VERSION] -m "Release v[VERSION]"
@@ -99,5 +105,4 @@ git push origin main
 git push origin v[VERSION]
 ```
 
-NEVER run git push yourself. The project owner must execute these commands
-manually. Git push to the public repo is irreversible.
+NEVER run git push yourself. The project owner must execute these commands manually.

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -18,7 +18,8 @@
 
 ## Current Version
 
-**v1.1.1** (pending release 2026-03-17) — patch: business rules IF/THEN/ELSE, conditionCount fix, DRY/SOLID refactoring, debug logger, Custom APIs click fix, env vars eye icon fix, CDS Default Solution filter fix, HTML cross-entity structure fix
+**v1.1.2** (pending git release 2026-03-17) — patch: cross-entity chain map redesign (trigger operation column, message code support), debug logging cleanup
+**v1.1.1** (released 2026-03-17) — patch: business rules IF/THEN/ELSE, conditionCount fix, DRY/SOLID refactoring, debug logger, Custom APIs click fix, env vars eye icon fix, CDS Default Solution filter fix, HTML cross-entity structure fix
 **v1.1.0** (released 2026-03-12) — minor: pipeline-first Cross-Entity Automation view, external API call detection, HTML/Markdown export parity, and AUDIT compliance fixes
 **v1.0.1** (released 2026-03-11) — patch: discovery pagination fix + OData injection guards
 **v1.0.0** (released 2026-03-11)
@@ -92,28 +93,21 @@ pnpm typecheck  # Type check
 
 ## In Progress / Known Limitations
 
-### Release v1.1.1 — In Progress (2026-03-17)
+### Release v1.1.2 — Documentation Finalized (2026-03-17)
 
-**Status:** Documentation and version files updated; awaiting project owner to run npm/git commands.
+**Status:** Documentation and version files complete; awaiting project owner for git operations.
 
 **Completed this session:**
-- Code review: Approved with comments (no blockers)
-- Security audit: CLEAR
-- CHANGELOG.md: `## [1.1.1] - 2026-03-17` entry written
-- README.md: version badge updated to `1.1.1`
-- `src/core/reporters/JsonReporter.ts`: `toolVersion` updated to `'1.1.1'`
-- `docs/user-guide.md` line 3: updated to `v1.1.1`
-- CHANGELOG comparison links: `[1.1.1]` entry added
+- CHANGELOG.md: `## [1.1.2] - 2026-03-17` entry created from latest commits (cross-entity chain map redesign, debug logging cleanup)
+- README.md: version badge updated to `1.1.2`
+- Verified all four files match: `package.json`, `npm-shrinkwrap.json`, `CHANGELOG.md`, `README.md` all show v1.1.2
 
 **Pending — project owner must run:**
-1. `npm version 1.1.1 --no-git-tag-version` — updates `package.json` + `npm-shrinkwrap.json`
-2. `pnpm typecheck && pnpm build` — build verification
-3. Stage and commit: `git add package.json npm-shrinkwrap.json CHANGELOG.md README.md src/core/reporters/JsonReporter.ts docs/user-guide.md`
-4. `git commit -m "chore: release v1.1.1"`
-5. `gh pr create ...` — create PR to main
-6. After PR merge: `git tag v1.1.1 -m "Release v1.1.1"` then push tag
-
-**Note:** `[PPSB-DIAG]` debug logs intentionally retained per project owner decision. Issue 3 (flow mislabelling) remains open for future diagnosis.
+1. `pnpm typecheck && pnpm build` — build verification
+2. Stage and commit: `git add CHANGELOG.md README.md`
+3. `git commit -m "chore: release v1.1.2"`
+4. `gh pr create ...` — create PR to main
+5. After PR merge: `git tag v1.1.2 -m "Release v1.1.2"` then push tag
 
 ### Released in v1.1.0 (2026-03-12)
 

--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -15,6 +15,8 @@ Invoke the **reviewer** agent.
 - The reviewer must return ✅ Approved or ⚠️ Approved with comments to proceed
 - If ❌ Changes required: stop, report blockers, wait for fixes before re-running
 
+**Progress:** Step 1 complete ✅ — Code review passed. / ❌ Step 1 failed — [blockers]. Release halted.
+
 ---
 
 ## Step 2: Security Audit
@@ -23,6 +25,8 @@ Invoke the **security-auditor** agent.
 - Scope: full sweep — source code AND .claude/ folder
 - If any CRITICAL or HIGH findings: stop, report findings, do not proceed
 - MEDIUM or LOW findings: report but may proceed at project owner's discretion
+
+**Progress:** Step 2 complete ✅ — Security audit passed. / ❌ Step 2 failed — [findings]. Release halted.
 
 ---
 
@@ -40,6 +44,8 @@ This updates **both** `package.json` and `npm-shrinkwrap.json` to the target
 version automatically. Do not proceed to Step 3b until the developer confirms
 both files are updated.
 
+**Progress:** Step 3a complete ✅ — package.json and npm-shrinkwrap.json updated to vX.Y.Z.
+
 ### Step 3b — Document-updater agent: Documentation
 
 Invoke the **document-updater** agent with these exact tasks:
@@ -56,6 +62,8 @@ Invoke the **document-updater** agent with these exact tasks:
 Do not proceed to Step 4 until the document-updater confirms all four files
 are consistent.
 
+**Progress:** Step 3b complete ✅ — CHANGELOG.md and README.md updated. All four files consistent on vX.Y.Z. / ❌ Step 3b failed — version mismatch: [detail]. Release halted.
+
 ---
 
 ## Step 4: Build Verification
@@ -64,6 +72,8 @@ Invoke the **developer** agent with these exact tasks, in this exact order:
 
 1. `pnpm typecheck` — must pass with zero errors. Stop if any errors.
 2. `pnpm build` — must complete successfully. Stop if it fails.
+
+**Progress:** Step 4 complete ✅ — Typecheck passed. Build succeeded. / ❌ Step 4 failed — [typecheck/build error]. Release halted.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Power Platform Solution Blueprint will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-03-17
+
+### Changed
+- **Cross-Entity Automation chain map redesigned** — trigger operation column added to show the specific operation (`Create`, `Update`, `Delete`) that causes the downstream automation; message code support expanded to handle all response scenario codes
+
+### Fixed
+- **Debug logging removed from production paths** — all `debugLog` calls removed from `FlowDefinitionParser.ts`, `FlowDiscovery.ts`, and `CrossEntityAnalyzer.ts`; conditional debug logger remains available opt-in via `ppsb-debug` localStorage flag for development diagnostics
+
+---
+
 ## [1.1.1] - 2026-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Complete architectural blueprints for your Power Platform solutions.
 
-![Version](https://img.shields.io/badge/version-1.1.1-blue)
+![Version](https://img.shields.io/badge/version-1.1.2-blue)
 ![Status](https://img.shields.io/badge/status-stable-green)
 
 Generate comprehensive technical documentation for Dataverse and Power Platform solutions with automated discovery, analysis, and export capabilities.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@sabrish/power-platform-solution-blueprint",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sabrish/power-platform-solution-blueprint",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-components": "^9.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabrish/power-platform-solution-blueprint",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "displayName": "Power Platform Solution Blueprint Generator",
   "description": "Generate comprehensive technical documentation for Dataverse and Power Platform solutions with automated discovery, analysis, and export capabilities.",
   "main": "index.html",

--- a/src/components/crossEntity/GlobalChainMapPanel.tsx
+++ b/src/components/crossEntity/GlobalChainMapPanel.tsx
@@ -4,7 +4,7 @@ import { ArrowRight24Regular } from '@fluentui/react-icons';
 import { FilterBar, FilterGroup } from '../FilterBar';
 import { EmptyState } from '../EmptyState';
 import { OperationBadge } from '../CrossEntityAutomation';
-import type { CrossEntityAnalysisResult } from '../../core';
+import type { CrossEntityAnalysisResult, CrossEntityChainLink } from '../../core';
 
 const useStyles = makeStyles({
   chainMapContainer: { display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalM },
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   },
   chainTable: {
     display: 'grid',
-    gridTemplateColumns: '1fr auto 1fr auto auto auto',
+    gridTemplateColumns: '1fr 1fr auto auto auto 1fr auto',
     gap: `${tokens.spacingVerticalXXS} ${tokens.spacingHorizontalM}`,
     alignItems: 'center',
   },
@@ -30,7 +30,31 @@ const useStyles = makeStyles({
   chainAutoCell: { display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalXXS },
   chainAutoBadge: { width: 'fit-content' },
   monoText: { fontFamily: 'Consolas, Monaco, monospace', fontSize: tokens.fontSizeBase200 },
+  monoMuted: { fontFamily: 'Consolas, Monaco, monospace', fontSize: tokens.fontSizeBase100, color: tokens.colorNeutralForeground2 },
+  monoTextMuted: { fontFamily: 'Consolas, Monaco, monospace', fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3 },
+  monoTextMutedItalic: { fontFamily: 'Consolas, Monaco, monospace', fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, fontStyle: 'italic' },
+  monoActionApiName: { fontFamily: 'Consolas, Monaco, monospace', fontSize: tokens.fontSizeBase100, color: tokens.colorNeutralForeground3, display: 'block' },
+  mutedItalic: { color: tokens.colorNeutralForeground3, fontStyle: 'italic' },
+  breakWord: { wordBreak: 'break-word' },
+  iconMuted: { color: tokens.colorNeutralForeground3 },
 });
+
+function triggerOperationLabel(op: CrossEntityChainLink['triggerOperation']): string {
+  switch (op) {
+    case 'Create': return 'Create';
+    case 'Update': return 'Update';
+    case 'Delete': return 'Delete';
+    case 'CreateOrUpdate': return 'Create or Update';
+    case 'Assign': return 'Assign';
+    case 'Grant': return 'Grant Access';
+    case 'Revoke': return 'Revoke Access';
+    case 'StatusChange': return 'Status Change';
+    case 'Manual': return 'Manual';
+    case 'Scheduled': return 'Scheduled';
+    case 'Action': return 'Custom Action';
+    default: return '—';
+  }
+}
 
 export interface GlobalChainMapPanelProps {
   analysis: CrossEntityAnalysisResult;
@@ -59,7 +83,30 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
         link.automationName.toLowerCase().includes(q)
       );
     })
-    .sort((a, b) => a.sourceEntityDisplayName.localeCompare(b.sourceEntityDisplayName));
+    .sort((a, b) => {
+      // 1. Source Trigger — real entities first, then pseudo-buckets
+      const aIsReal = !a.sourceEntity.startsWith('(');
+      const bIsReal = !b.sourceEntity.startsWith('(');
+      if (aIsReal !== bIsReal) return aIsReal ? -1 : 1;
+      const srcCmp = a.sourceEntityDisplayName.localeCompare(b.sourceEntityDisplayName);
+      if (srcCmp !== 0) return srcCmp;
+      // 2. Automation name
+      const autoCmp = a.automationName.localeCompare(b.automationName);
+      if (autoCmp !== 0) return autoCmp;
+      // 3. Trigger operation
+      const triggerOrder = ['Create', 'Update', 'Delete', 'CreateOrUpdate', 'Action', 'Manual', 'Scheduled', 'Unknown'];
+      const tA = triggerOrder.indexOf(a.triggerOperation);
+      const tB = triggerOrder.indexOf(b.triggerOperation);
+      if (tA !== tB) return tA - tB;
+      // 4. Mode (Sync before Async)
+      if (a.isAsynchronous !== b.isAsynchronous) return a.isAsynchronous ? 1 : -1;
+      // 5. Target entity
+      const tgtCmp = a.targetEntityDisplayName.localeCompare(b.targetEntityDisplayName);
+      if (tgtCmp !== 0) return tgtCmp;
+      // 6. Target operation
+      const opOrder = ['Create', 'Update', 'Delete', 'Action'];
+      return opOrder.indexOf(a.operation) - opOrder.indexOf(b.operation);
+    });
 
   return (
     <div className={styles.chainMapContainer}>
@@ -90,7 +137,7 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
           ))}
         </FilterGroup>
         <FilterGroup
-          label="Operation:"
+          label="Target Operation:"
           hasActiveFilters={filterOperation !== 'all'}
           onClear={() => setFilterOperation('all')}
         >
@@ -116,52 +163,45 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
       ) : (
         <Card>
           <div className={styles.chainTable}>
-            <Text className={styles.chainTableHeader}>Source Entity</Text>
+            {/* Headers: Source Trigger | Automation | Trigger Operation | Mode | → | Target Entity | Target Operation */}
+            <Text className={styles.chainTableHeader}>Source Trigger</Text>
+            <Text className={styles.chainTableHeader}>Automation</Text>
+            <Text className={styles.chainTableHeader}>Trigger Operation</Text>
+            <Text className={styles.chainTableHeader}>Mode</Text>
             <span />
             <Text className={styles.chainTableHeader}>Target Entity</Text>
-            <Text className={styles.chainTableHeader}>Automation</Text>
-            <Text className={styles.chainTableHeader}>Operation</Text>
-            <Text className={styles.chainTableHeader}>Mode</Text>
+            <Text className={styles.chainTableHeader}>Target Operation</Text>
+
             {filteredLinks.map((link, i) => (
               <Fragment key={i}>
+                {/* Source Trigger */}
                 <div>
-                  <Text weight="semibold">{link.sourceEntityDisplayName}</Text>
-                  <br />
-                  <Text
-                    className={styles.monoText}
-                    style={{ color: tokens.colorNeutralForeground3 }}
-                  >
-                    {link.sourceEntity}
-                  </Text>
-                </div>
-                <ArrowRight24Regular style={{ color: tokens.colorNeutralForeground3 }} />
-                <div>
-                  <Text weight="semibold">{link.targetEntityDisplayName}</Text>
-                  {link.targetEntity !== '(unbound)' && (
+                  {link.sourceEntity === '(custom-action)' ? (
                     <>
+                      <Text weight="semibold">Custom Action</Text>
                       <br />
-                      <Text
-                        className={styles.monoText}
-                        style={{ color: tokens.colorNeutralForeground3 }}
-                      >
-                        {link.targetEntity}
+                      <Text className={styles.monoTextMuted}>
+                        {link.sourceEntityDisplayName.replace('Custom Action: ', '')}
                       </Text>
                     </>
-                  )}
-                  {link.targetEntity === '(unbound)' && (
+                  ) : link.sourceEntity.startsWith('(') ? (
+                    <Text className={styles.mutedItalic}>
+                      (unbound)
+                    </Text>
+                  ) : (
                     <>
+                      <Text weight="semibold">{link.sourceEntityDisplayName}</Text>
                       <br />
-                      <Text
-                        className={styles.monoText}
-                        style={{ color: tokens.colorNeutralForeground3, fontStyle: 'italic' }}
-                      >
-                        No entity target — effects not traceable
+                      <Text className={styles.monoTextMuted}>
+                        {link.sourceEntity}
                       </Text>
                     </>
                   )}
                 </div>
+
+                {/* Automation */}
                 <div className={styles.chainAutoCell}>
-                  <Text style={{ wordBreak: 'break-word' }}>{link.automationName}</Text>
+                  <Text className={styles.breakWord}>{link.automationName}</Text>
                   <Badge
                     appearance="outline"
                     shape="rounded"
@@ -171,21 +211,19 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
                     {link.automationType}
                   </Badge>
                 </div>
+
+                {/* Trigger Operation */}
                 <div>
-                  <OperationBadge operation={link.operation} />
-                  {link.operation === 'Action' && link.customActionApiName && (
-                    <Text
-                      className={styles.monoText}
-                      style={{
-                        color: tokens.colorNeutralForeground3,
-                        display: 'block',
-                        fontSize: tokens.fontSizeBase100,
-                      }}
-                    >
-                      {link.customActionApiName}
-                    </Text>
+                  <Text>{triggerOperationLabel(link.triggerOperation)}</Text>
+                  {link.triggerOperation === 'Action' && link.triggerCustomActionName && (
+                    <>
+                      <br />
+                      <Text className={styles.monoMuted}>{link.triggerCustomActionName}</Text>
+                    </>
                   )}
                 </div>
+
+                {/* Mode */}
                 <Badge
                   appearance="tint"
                   shape="rounded"
@@ -193,6 +231,40 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
                 >
                   {link.isAsynchronous ? 'Async' : 'Sync'}
                 </Badge>
+
+                {/* Arrow */}
+                <ArrowRight24Regular className={styles.iconMuted} />
+
+                {/* Target Entity */}
+                <div>
+                  <Text weight="semibold">{link.targetEntityDisplayName}</Text>
+                  {link.targetEntity !== '(unbound)' && (
+                    <>
+                      <br />
+                      <Text className={styles.monoTextMuted}>
+                        {link.targetEntity}
+                      </Text>
+                    </>
+                  )}
+                  {link.targetEntity === '(unbound)' && (
+                    <>
+                      <br />
+                      <Text className={styles.monoTextMutedItalic}>
+                        No entity target — effects not traceable
+                      </Text>
+                    </>
+                  )}
+                </div>
+
+                {/* Target Operation */}
+                <div>
+                  <OperationBadge operation={link.operation} />
+                  {link.operation === 'Action' && link.customActionApiName && (
+                    <Text className={styles.monoActionApiName}>
+                      {link.customActionApiName}
+                    </Text>
+                  )}
+                </div>
               </Fragment>
             ))}
           </div>

--- a/src/components/crossEntity/GlobalChainMapPanel.tsx
+++ b/src/components/crossEntity/GlobalChainMapPanel.tsx
@@ -94,7 +94,7 @@ export function GlobalChainMapPanel({ analysis }: GlobalChainMapPanelProps): JSX
       const autoCmp = a.automationName.localeCompare(b.automationName);
       if (autoCmp !== 0) return autoCmp;
       // 3. Trigger operation
-      const triggerOrder = ['Create', 'Update', 'Delete', 'CreateOrUpdate', 'Action', 'Manual', 'Scheduled', 'Unknown'];
+      const triggerOrder = ['Create', 'Update', 'Delete', 'CreateOrUpdate', 'Assign', 'Grant', 'Revoke', 'StatusChange', 'Action', 'Manual', 'Scheduled', 'Unknown'];
       const tA = triggerOrder.indexOf(a.triggerOperation);
       const tB = triggerOrder.indexOf(b.triggerOperation);
       if (tA !== tB) return tA - tB;

--- a/src/core/analyzers/CrossEntityAnalyzer.ts
+++ b/src/core/analyzers/CrossEntityAnalyzer.ts
@@ -102,6 +102,8 @@ export class CrossEntityAnalyzer {
           targetEntityDisplayName: targetDisplayName,
           automationName: ep.automationName,
           automationType: ep.automationType,
+          triggerOperation: ep.triggerOperation,
+          ...(ep.triggerCustomActionName ? { triggerCustomActionName: ep.triggerCustomActionName } : {}),
           operation: ep.operation,
           isAsynchronous: ep.isAsynchronous,
           ...(ep.customActionApiName ? { customActionApiName: ep.customActionApiName } : {}),
@@ -426,6 +428,12 @@ export class CrossEntityAnalyzer {
       const key = `${flow.id}:${action.customActionApiName ?? action.actionName}`;
       if (seen.has(key)) return;
       seen.add(key);
+      const unboundTriggerOp: CrossEntityChainLink['triggerOperation'] =
+        sourceEntity === '(scheduled)' ? 'Scheduled'
+        : sourceEntity === '(manual)' ? 'Manual'
+        : sourceEntity === '(custom-action)' ? 'Action'
+        : flow.definition.triggerEvent as CrossEntityChainLink['triggerOperation'];
+
       links.push({
         sourceEntity,
         sourceEntityDisplayName: sourceDisplayName,
@@ -433,6 +441,8 @@ export class CrossEntityAnalyzer {
         targetEntityDisplayName: 'Unbound Custom Action / API',
         automationName: flow.name,
         automationType: 'Flow',
+        triggerOperation: unboundTriggerOp,
+        ...(flow.definition.triggerCustomActionName ? { triggerCustomActionName: flow.definition.triggerCustomActionName } : {}),
         operation: 'Action',
         isAsynchronous: true,
         ...(action.customActionApiName ? { customActionApiName: action.customActionApiName } : {}),
@@ -458,29 +468,33 @@ export class CrossEntityAnalyzer {
       const entityName =
         resolveEntityName(flow.entity) ??
         resolveEntityName(flow.definition.triggerEntity);
+      const customActionName = flow.definition.triggerCustomActionName ?? null;
       const sourceEntity = entityName?.toLowerCase()
         ?? (flow.definition.triggerType === 'Scheduled' ? '(scheduled)'
           : flow.definition.triggerType === 'Manual' ? '(manual)'
+          : (flow.definition.triggerType === 'Dataverse' && customActionName) ? '(custom-action)'
           : '(unscoped)');
       const sourceDisplayName = entityName
         ? entityDisplayMap.get(sourceEntity) || entityName
         : flow.definition.triggerType === 'Scheduled' ? 'Scheduled Flow'
         : flow.definition.triggerType === 'Manual' ? 'Manual / On-Demand Flow'
-        : (() => {
-            return 'Solution Flow';
-          })();
-      debugLog('flow-scope', `[unbound] ${flow.name} → label="${sourceDisplayName}"`, {
-        id: flow.id,
-        'flow.entity': flow.entity,
-        'triggerEntity': flow.definition.triggerEntity,
-        triggerType: flow.definition.triggerType,
-        resolvedEntityName: entityName,
-        sourceEntity,
-        sourceDisplayName,
-      });
-      for (const action of flow.definition.dataverseActions ?? []) {
-        if (!action.isUnbound) continue;
-        addLink(sourceEntity, sourceDisplayName, flow, action);
+        : (flow.definition.triggerType === 'Dataverse' && customActionName) ? `Custom Action: ${customActionName}`
+        : 'Solution Flow';
+      const unboundActions = (flow.definition.dataverseActions ?? []).filter(a => a.isUnbound);
+      if (unboundActions.length > 0) {
+        debugLog('flow-scope', `[unbound] ${flow.name} → label="${sourceDisplayName}"`, {
+          id: flow.id,
+          'flow.entity': flow.entity,
+          'triggerEntity': flow.definition.triggerEntity,
+          triggerType: flow.definition.triggerType,
+          resolvedEntityName: entityName,
+          sourceEntity,
+          sourceDisplayName,
+          unboundActionCount: unboundActions.length,
+        });
+        for (const action of unboundActions) {
+          addLink(sourceEntity, sourceDisplayName, flow, action);
+        }
       }
     }
 
@@ -562,6 +576,8 @@ export class CrossEntityAnalyzer {
             isScheduled: flow.definition.triggerType === 'Scheduled',
             isOnDemand: flow.definition.triggerType === 'Manual',
             confidence: action.confidence,
+            triggerOperation: flow.definition.triggerEvent as CrossEntityEntryPoint['triggerOperation'],
+            ...(flow.definition.triggerCustomActionName ? { triggerCustomActionName: flow.definition.triggerCustomActionName } : {}),
             ...(action.customActionApiName ? { customActionApiName: action.customActionApiName } : {}),
           });
         }
@@ -572,6 +588,8 @@ export class CrossEntityAnalyzer {
             flow,
             sourceEntity,
             sourceDisplayName,
+            flow.definition.triggerEvent as CrossEntityEntryPoint['triggerOperation'],
+            flow.definition.triggerCustomActionName,
             flow.definition.childFlowIds,
             allFlowsById,
             new Set([flow.id.toLowerCase()]),
@@ -603,6 +621,7 @@ export class CrossEntityAnalyzer {
       let sourceEntity: string;
       let sourceDisplayName: string;
 
+      const customActionName = flow.definition.triggerCustomActionName ?? null;
       if (entityName) {
         sourceEntity = entityName.toLowerCase();
         sourceDisplayName = entityDisplayMap.get(sourceEntity) || entityName;
@@ -612,10 +631,19 @@ export class CrossEntityAnalyzer {
       } else if (triggerType === 'Manual') {
         sourceEntity = '(manual)';
         sourceDisplayName = 'Manual / On-Demand Flow';
+      } else if (triggerType === 'Dataverse' && customActionName) {
+        sourceEntity = '(custom-action)';
+        sourceDisplayName = `Custom Action: ${customActionName}`;
       } else {
         sourceEntity = '(unscoped)';
         sourceDisplayName = 'Solution Flow';
       }
+      const triggerOp: CrossEntityEntryPoint['triggerOperation'] =
+        triggerType === 'Scheduled' ? 'Scheduled'
+        : triggerType === 'Manual' ? 'Manual'
+        : (triggerType === 'Dataverse' && !!customActionName) ? 'Action'
+        : flow.definition.triggerEvent as CrossEntityEntryPoint['triggerOperation'];
+
       debugLog('flow-scope', `[entry-point] ${flow.name} → label="${sourceDisplayName}"`, {
         id: flow.id,
         'flow.entity': flow.entity,
@@ -645,6 +673,8 @@ export class CrossEntityAnalyzer {
           isScheduled: triggerType === 'Scheduled',
           isOnDemand: triggerType === 'Manual',
           confidence: action.confidence,
+          triggerOperation: triggerOp,
+          ...(flow.definition.triggerCustomActionName ? { triggerCustomActionName: flow.definition.triggerCustomActionName } : {}),
           ...(action.customActionApiName ? { customActionApiName: action.customActionApiName } : {}),
         });
       }
@@ -655,6 +685,8 @@ export class CrossEntityAnalyzer {
           flow,
           sourceEntity,
           sourceDisplayName,
+          triggerOp,
+          flow.definition.triggerCustomActionName,
           flow.definition.childFlowIds,
           allFlowsById,
           new Set([flow.id.toLowerCase()]),
@@ -669,6 +701,14 @@ export class CrossEntityAnalyzer {
 
       const sourceEntity = wf.entity.toLowerCase();
       const sourceDisplayName = entityDisplayMap.get(sourceEntity) || sourceEntity;
+
+      const wfTriggerOp: CrossEntityEntryPoint['triggerOperation'] =
+        wf.onDemand ? 'Manual'
+        : wf.triggerOnCreate && !wf.triggerOnUpdate && !wf.triggerOnDelete ? 'Create'
+        : !wf.triggerOnCreate && wf.triggerOnUpdate && !wf.triggerOnDelete ? 'Update'
+        : !wf.triggerOnCreate && !wf.triggerOnUpdate && wf.triggerOnDelete ? 'Delete'
+        : wf.triggerOnCreate && wf.triggerOnUpdate ? 'CreateOrUpdate'
+        : 'Unknown';
 
       const xamlSteps = ClassicWorkflowXamlParser.parse(wf.xaml);
       for (const step of xamlSteps) {
@@ -687,6 +727,7 @@ export class CrossEntityAnalyzer {
           isScheduled: false,
           isOnDemand: wf.onDemand,
           confidence: step.confidence,
+          triggerOperation: wfTriggerOp,
         });
       }
     }
@@ -702,6 +743,8 @@ export class CrossEntityAnalyzer {
     parentFlow: Flow,
     sourceEntity: string,
     sourceDisplayName: string,
+    triggerOperation: CrossEntityEntryPoint['triggerOperation'],
+    triggerCustomActionName: string | undefined,
     childFlowIds: string[],
     allFlowsById: Map<string, { flow: Flow; sourceEntity: string }>,
     visited: Set<string>,
@@ -736,6 +779,8 @@ export class CrossEntityAnalyzer {
           isOnDemand: childFlow.definition.triggerType === 'Manual',
           // Downgrade confidence for child flows (we don't know if parent always calls child)
           confidence: action.confidence === 'High' ? 'Medium' : action.confidence,
+          triggerOperation,
+          ...(triggerCustomActionName ? { triggerCustomActionName } : {}),
           ...(action.customActionApiName ? { customActionApiName: action.customActionApiName } : {}),
         });
       }
@@ -746,6 +791,8 @@ export class CrossEntityAnalyzer {
           childFlow,
           sourceEntity,
           sourceDisplayName,
+          triggerOperation,
+          triggerCustomActionName,
           childFlow.definition.childFlowIds,
           allFlowsById,
           visited,

--- a/src/core/analyzers/CrossEntityAnalyzer.ts
+++ b/src/core/analyzers/CrossEntityAnalyzer.ts
@@ -15,7 +15,6 @@ import type {
 } from '../types/crossEntityTrace.js';
 import { ClassicWorkflowXamlParser } from '../parsers/ClassicWorkflowXamlParser.js';
 import { resolveEntityName } from '../utils/entityName.js';
-import { debugLog } from '../utils/debugLogger.js';
 
 /**
  * Performs 4-layer cross-entity automation analysis:
@@ -163,21 +162,10 @@ export class CrossEntityAnalyzer {
         // Flows triggered on this entity for this message
         for (const flow of bp.flows) {
           if (flow.definition.triggerType !== 'Dataverse') {
-            debugLog('flow-scope', `SKIP (non-Dataverse) [${message}] ${flow.name}`, {
-              id: flow.id, entity: entityKey,
-              triggerType: flow.definition.triggerType,
-              'flow.entity': flow.entity,
-              'triggerEntity': flow.definition.triggerEntity,
-            });
             continue;
           }
           const flowTriggerEntity = flow.definition.triggerEntity?.toLowerCase();
           if (flowTriggerEntity && flowTriggerEntity !== entityKey) {
-            debugLog('flow-scope', `SKIP (entity mismatch) [${message}] ${flow.name}`, {
-              id: flow.id, bpEntity: entityKey,
-              flowTriggerEntity,
-              triggerType: flow.definition.triggerType,
-            });
             continue;
           }
           if (!this.triggerMatchesOperation(flow.definition.triggerEvent, message)) continue;
@@ -482,16 +470,6 @@ export class CrossEntityAnalyzer {
         : 'Solution Flow';
       const unboundActions = (flow.definition.dataverseActions ?? []).filter(a => a.isUnbound);
       if (unboundActions.length > 0) {
-        debugLog('flow-scope', `[unbound] ${flow.name} → label="${sourceDisplayName}"`, {
-          id: flow.id,
-          'flow.entity': flow.entity,
-          'triggerEntity': flow.definition.triggerEntity,
-          triggerType: flow.definition.triggerType,
-          resolvedEntityName: entityName,
-          sourceEntity,
-          sourceDisplayName,
-          unboundActionCount: unboundActions.length,
-        });
         for (const action of unboundActions) {
           addLink(sourceEntity, sourceDisplayName, flow, action);
         }
@@ -643,16 +621,6 @@ export class CrossEntityAnalyzer {
         : triggerType === 'Manual' ? 'Manual'
         : (triggerType === 'Dataverse' && !!customActionName) ? 'Action'
         : flow.definition.triggerEvent as CrossEntityEntryPoint['triggerOperation'];
-
-      debugLog('flow-scope', `[entry-point] ${flow.name} → label="${sourceDisplayName}"`, {
-        id: flow.id,
-        'flow.entity': flow.entity,
-        'triggerEntity': flow.definition.triggerEntity,
-        triggerType,
-        resolvedEntityName: entityName,
-        sourceEntity,
-        sourceDisplayName,
-      });
 
       for (const action of flow.definition.dataverseActions ?? []) {
         if (action.isUnbound) continue; // handled separately in collectUnboundChainLinks

--- a/src/core/discovery/FlowDiscovery.ts
+++ b/src/core/discovery/FlowDiscovery.ts
@@ -138,7 +138,7 @@ export class FlowDiscovery implements IDiscoverer<Flow> {
   }
 
   private mapToFlow(record: WorkflowMetaRecord, clientdata: string | null): Flow {
-    const definition = FlowDefinitionParser.parse(clientdata);
+    const definition = FlowDefinitionParser.parse(clientdata, record.name);
     debugLog('flow-discovery', `mapToFlow: ${record.name}`, {
       workflowid: record.workflowid,
       primaryentity: record.primaryentity,

--- a/src/core/discovery/FlowDiscovery.ts
+++ b/src/core/discovery/FlowDiscovery.ts
@@ -3,7 +3,6 @@ import type { Flow } from '../types/blueprint.js';
 import type { FetchLogger } from '../utils/FetchLogger.js';
 import type { IDiscoverer } from './IDiscoverer.js';
 import { FlowDefinitionParser } from '../parsers/FlowDefinitionParser.js';
-import { debugLog } from '../utils/debugLogger.js';
 import { withAdaptiveBatch } from '../utils/withAdaptiveBatch.js';
 import { buildOrFilter } from '../utils/odata.js';
 import { normalizeGuid } from '../utils/guid.js';
@@ -139,14 +138,6 @@ export class FlowDiscovery implements IDiscoverer<Flow> {
 
   private mapToFlow(record: WorkflowMetaRecord, clientdata: string | null): Flow {
     const definition = FlowDefinitionParser.parse(clientdata, record.name);
-    debugLog('flow-discovery', `mapToFlow: ${record.name}`, {
-      workflowid: record.workflowid,
-      primaryentity: record.primaryentity,
-      scope: record.scope,
-      triggerType: definition.triggerType,
-      triggerEntity: definition.triggerEntity,
-      hasClientdata: clientdata !== null,
-    });
 
     let state: Flow['state'] = 'Draft';
     if (record.statecode === 1) state = 'Active';

--- a/src/core/parsers/FlowDefinitionParser.ts
+++ b/src/core/parsers/FlowDefinitionParser.ts
@@ -114,7 +114,7 @@ export class FlowDefinitionParser {
       triggerType = 'Dataverse';
 
       // Modern Dataverse connector: event is a numeric message code in parameters
-      // 1 = Create, 2 = Delete, 3 = Update, 4 = CreateOrUpdate, 5 = Assign, 8 = SetState
+      // 1 = Create, 2 = Delete, 3 = Update, 4 = CreateOrUpdate, 5 = Assign, 6 = Grant, 7 = Revoke, 8 = StatusChange
       const messageCode = trigger.inputs?.parameters?.['subscriptionRequest/message'];
       if (messageCode !== undefined && messageCode !== null) {
         const code = Number(messageCode);

--- a/src/core/parsers/FlowDefinitionParser.ts
+++ b/src/core/parsers/FlowDefinitionParser.ts
@@ -1,5 +1,4 @@
 import type { FlowDefinition, ExternalCall, DataverseAction } from '../types/blueprint.js';
-import { debugLog } from '../utils/debugLogger.js';
 
 /**
  * Parses Power Automate flow definitions from clientdata JSON
@@ -14,8 +13,7 @@ export class FlowDefinitionParser {
   /**
    * Parse flow definition from clientdata JSON string
    */
-  static parse(clientdata: string | null, flowName?: string): FlowDefinition {
-    const label = flowName ?? '(unknown)';
+  static parse(clientdata: string | null, _flowName?: string): FlowDefinition {
     const defaultDefinition: FlowDefinition = {
       triggerType: 'Other',
       triggerEvent: 'Unknown',
@@ -29,7 +27,6 @@ export class FlowDefinitionParser {
     };
 
     if (!clientdata) {
-      debugLog('flow-parse', `[${label}] clientdata is null — returning default definition`);
       return defaultDefinition;
     }
 
@@ -51,18 +48,6 @@ export class FlowDefinitionParser {
       // Extract scope/run as information
       const scopeType = this.extractScopeType(data);
 
-      debugLog('flow-parse', `[${label}] parse complete: ${trigger.type}/${trigger.event}`, {
-        triggerEntity: trigger.entity,
-        actionsCount,
-        dataverseActionsCount: dataverseActions.length,
-        dataverseActions: dataverseActions.length > 0
-          ? dataverseActions.map(a => `${a.operation}→${a.targetEntity || '[unbound]'} (${a.confidence})`)
-          : undefined,
-        externalCallsCount: externalCalls.length,
-        childFlowIdsCount: childFlowIds.length,
-        scopeType,
-      });
-
       return {
         triggerType: trigger.type,
         triggerEvent: trigger.event,
@@ -76,8 +61,7 @@ export class FlowDefinitionParser {
         dataverseActions,
         ...(childFlowIds.length > 0 ? { childFlowIds } : {}),
       };
-    } catch (error) {
-      debugLog('flow-parse', `[${label}] JSON parse failed`, { error: error instanceof Error ? error.message : String(error) });
+    } catch {
       return defaultDefinition;
     }
   }
@@ -104,13 +88,8 @@ export class FlowDefinitionParser {
     const trigger = definition.triggers[triggerKey];
 
     if (!trigger) {
-      debugLog('flow-parse', `no trigger found (triggerKey="${triggerKey}")`);
       return { type: 'Other', event: 'Unknown', entity: null, conditions: null, customActionName: null };
     }
-
-    debugLog('flow-parse', `trigger: key="${triggerKey}" type="${trigger.type}"`, {
-      apiId: (trigger.inputs?.host?.apiId || ''),
-    });
 
     // Determine trigger type
     let triggerType: FlowDefinition['triggerType'] = 'Other';
@@ -137,7 +116,6 @@ export class FlowDefinitionParser {
       // Modern Dataverse connector: event is a numeric message code in parameters
       // 1 = Create, 2 = Delete, 3 = Update, 4 = CreateOrUpdate, 5 = Assign, 8 = SetState
       const messageCode = trigger.inputs?.parameters?.['subscriptionRequest/message'];
-      debugLog('flow-parse', `Dataverse message code: ${messageCode ?? '(absent)'}`);
       if (messageCode !== undefined && messageCode !== null) {
         const code = Number(messageCode);
         if (code === 1) triggerEvent = 'Create';
@@ -181,14 +159,7 @@ export class FlowDefinitionParser {
           else if (triggerKind.includes('update')) triggerEvent = 'Update';
           else if (triggerKind.includes('delete')) triggerEvent = 'Delete';
           else {
-            // Log parameter keys and relevant values to aid future diagnosis
-            const params = trigger.inputs?.parameters ?? {};
-            const paramKeys = Object.keys(params);
-            debugLog('flow-parse', `Dataverse trigger event Unknown — param keys: [${paramKeys.join(', ')}]`, {
-              sdkmessagename: params['subscriptionRequest/sdkmessagename'],
-              catalog: params['catalog'],
-              category: params['category'],
-            });
+            // triggerEvent remains 'Unknown'
           }
         }
       }
@@ -217,23 +188,6 @@ export class FlowDefinitionParser {
         if (rawActionName && typeof rawActionName === 'string') {
           customActionName = rawActionName;
         }
-        debugLog('flow-parse', 'Dataverse trigger — triggerEntity=null', {
-          triggerKind, apiId,
-          customActionName,
-          parameters: trigger.inputs?.parameters,
-        });
-      } else {
-        debugLog('flow-parse', `Dataverse trigger — triggerEntity="${triggerEntity}"`, {
-          triggerKind, apiId,
-          resolvedFrom: (
-            trigger.inputs?.parameters?.['subscriptionRequest/entityname'] ? 'subscriptionRequest/entityname' :
-            trigger.inputs?.body?.EntityLogicalName ? 'body.EntityLogicalName' :
-            trigger.inputs?.parameters?.EntityLogicalName ? 'parameters.EntityLogicalName' :
-            trigger.inputs?.parameters?.entityName ? 'parameters.entityName' :
-            trigger.inputs?.parameters?.entityLogicalName ? 'parameters.entityLogicalName' :
-            'metadata.entityName'
-          ),
-        });
       }
 
       // Filter conditions — try modern connector path first, then legacy paths
@@ -259,27 +213,10 @@ export class FlowDefinitionParser {
 
       if (entityType && typeof entityType === 'string' && entityType.toLowerCase() !== 'none') {
         triggerEntity = entityType.toLowerCase();
-        debugLog('flow-parse', `Manual trigger — entity-bound triggerEntity="${triggerEntity}"`, {
-          resolvedFrom: schema?.body?.properties?.entity?.properties?.entityType?.default ? 'schema.body.entity.entityType' :
-            schema?.entity?.properties?.entityType?.default ? 'schema.entity.entityType' :
-            schema?.entity?.schema?.properties?.entityType?.default ? 'schema.entity.schema.entityType' :
-            'host.schema.entityLogicalName',
-        });
-      } else {
-        debugLog('flow-parse', `Manual trigger — no entity binding found`, {
-          schemaKeys: schema ? Object.keys(schema) : null,
-          hostKeys: trigger.inputs?.host ? Object.keys(trigger.inputs.host) : null,
-        });
       }
     } else if (triggerKind.includes('recurrence') || triggerKind.includes('schedule')) {
       triggerType = 'Scheduled';
       triggerEvent = 'Scheduled';
-    } else {
-      debugLog('flow-parse', `triggerType=Other (no pattern matched)`, {
-        triggerKind, apiId,
-        'trigger.type': trigger.type,
-        'inputs.host': trigger.inputs?.host,
-      });
     }
 
     return { type: triggerType, event: triggerEvent, entity: triggerEntity, conditions, customActionName };

--- a/src/core/parsers/FlowDefinitionParser.ts
+++ b/src/core/parsers/FlowDefinitionParser.ts
@@ -14,7 +14,8 @@ export class FlowDefinitionParser {
   /**
    * Parse flow definition from clientdata JSON string
    */
-  static parse(clientdata: string | null): FlowDefinition {
+  static parse(clientdata: string | null, flowName?: string): FlowDefinition {
+    const label = flowName ?? '(unknown)';
     const defaultDefinition: FlowDefinition = {
       triggerType: 'Other',
       triggerEvent: 'Unknown',
@@ -28,7 +29,7 @@ export class FlowDefinitionParser {
     };
 
     if (!clientdata) {
-      debugLog('flow-parse', 'clientdata is null — returning default definition');
+      debugLog('flow-parse', `[${label}] clientdata is null — returning default definition`);
       return defaultDefinition;
     }
 
@@ -50,10 +51,13 @@ export class FlowDefinitionParser {
       // Extract scope/run as information
       const scopeType = this.extractScopeType(data);
 
-      debugLog('flow-parse', `parse complete: ${trigger.type}/${trigger.event}`, {
+      debugLog('flow-parse', `[${label}] parse complete: ${trigger.type}/${trigger.event}`, {
         triggerEntity: trigger.entity,
         actionsCount,
         dataverseActionsCount: dataverseActions.length,
+        dataverseActions: dataverseActions.length > 0
+          ? dataverseActions.map(a => `${a.operation}→${a.targetEntity || '[unbound]'} (${a.confidence})`)
+          : undefined,
         externalCallsCount: externalCalls.length,
         childFlowIdsCount: childFlowIds.length,
         scopeType,
@@ -64,6 +68,7 @@ export class FlowDefinitionParser {
         triggerEvent: trigger.event,
         triggerEntity: trigger.entity,
         triggerConditions: trigger.conditions,
+        ...(trigger.customActionName ? { triggerCustomActionName: trigger.customActionName } : {}),
         scopeType,
         actionsCount,
         externalCalls,
@@ -72,7 +77,7 @@ export class FlowDefinitionParser {
         ...(childFlowIds.length > 0 ? { childFlowIds } : {}),
       };
     } catch (error) {
-      debugLog('flow-parse', 'JSON parse failed', { error: error instanceof Error ? error.message : String(error) });
+      debugLog('flow-parse', `[${label}] JSON parse failed`, { error: error instanceof Error ? error.message : String(error) });
       return defaultDefinition;
     }
   }
@@ -85,12 +90,13 @@ export class FlowDefinitionParser {
     event: FlowDefinition['triggerEvent'];
     entity: string | null;
     conditions: string | null;
+    customActionName: string | null;
   } {
     const properties = data?.properties;
     const definition = properties?.definition;
 
     if (!definition || !definition.triggers) {
-      return { type: 'Other', event: 'Unknown', entity: null, conditions: null };
+      return { type: 'Other', event: 'Unknown', entity: null, conditions: null, customActionName: null };
     }
 
     // Get first trigger (flows typically have one trigger)
@@ -99,7 +105,7 @@ export class FlowDefinitionParser {
 
     if (!trigger) {
       debugLog('flow-parse', `no trigger found (triggerKey="${triggerKey}")`);
-      return { type: 'Other', event: 'Unknown', entity: null, conditions: null };
+      return { type: 'Other', event: 'Unknown', entity: null, conditions: null, customActionName: null };
     }
 
     debugLog('flow-parse', `trigger: key="${triggerKey}" type="${trigger.type}"`, {
@@ -111,6 +117,7 @@ export class FlowDefinitionParser {
     let triggerEvent: FlowDefinition['triggerEvent'] = 'Unknown';
     let triggerEntity: string | null = null;
     let conditions: string | null = null;
+    let customActionName: string | null = null;
 
     const triggerKind = trigger.type?.toLowerCase() || '';
 
@@ -128,27 +135,67 @@ export class FlowDefinitionParser {
       triggerType = 'Dataverse';
 
       // Modern Dataverse connector: event is a numeric message code in parameters
-      // 1 = Create, 2 = Delete, 3 = Update, 4 = CreateOrUpdate
+      // 1 = Create, 2 = Delete, 3 = Update, 4 = CreateOrUpdate, 5 = Assign, 8 = SetState
       const messageCode = trigger.inputs?.parameters?.['subscriptionRequest/message'];
+      debugLog('flow-parse', `Dataverse message code: ${messageCode ?? '(absent)'}`);
       if (messageCode !== undefined && messageCode !== null) {
         const code = Number(messageCode);
         if (code === 1) triggerEvent = 'Create';
         else if (code === 2) triggerEvent = 'Delete';
         else if (code === 3) triggerEvent = 'Update';
         else if (code === 4) triggerEvent = 'CreateOrUpdate';
+        else if (code === 5) triggerEvent = 'Assign';
+        else if (code === 6) triggerEvent = 'Grant';
+        else if (code === 7) triggerEvent = 'Revoke';
+        else if (code === 8) triggerEvent = 'StatusChange';
       } else {
-        // Legacy connector: infer event from trigger type string
-        if (triggerKind.includes('create')) {
-          triggerEvent = 'Create';
-        } else if (triggerKind.includes('update')) {
-          triggerEvent = 'Update';
-        } else if (triggerKind.includes('delete')) {
-          triggerEvent = 'Delete';
+        // Fallback 1: older format stores message as plain 'message' (no subscriptionRequest/ prefix)
+        const legacyCode = trigger.inputs?.parameters?.message;
+        if (legacyCode !== undefined && legacyCode !== null) {
+          const code = Number(legacyCode);
+          if (code === 1) triggerEvent = 'Create';
+          else if (code === 2) triggerEvent = 'Delete';
+          else if (code === 3) triggerEvent = 'Update';
+          else if (code === 4) triggerEvent = 'CreateOrUpdate';
+          else if (code === 5) triggerEvent = 'Assign';
+          else if (code === 6) triggerEvent = 'Grant';
+          else if (code === 7) triggerEvent = 'Revoke';
+          else if (code === 8) triggerEvent = 'StatusChange';
+        } else {
+          // Fallback 2: sdkMessageName string (subscriptionRequest/sdkmessagename)
+          const rawSdkMsg = trigger.inputs?.parameters?.['subscriptionRequest/sdkmessagename'];
+          const sdkMsg = rawSdkMsg ? String(rawSdkMsg).toLowerCase() : '';
+          if (sdkMsg === 'create') triggerEvent = 'Create';
+          else if (sdkMsg === 'update') triggerEvent = 'Update';
+          else if (sdkMsg === 'delete') triggerEvent = 'Delete';
+          else if (sdkMsg === 'createorupdate') triggerEvent = 'CreateOrUpdate';
+          else if (sdkMsg === 'assign') triggerEvent = 'Assign';
+          else if (sdkMsg === 'grantaccess') triggerEvent = 'Grant';
+          else if (sdkMsg === 'revokeaccess') triggerEvent = 'Revoke';
+          else if (sdkMsg === 'setstate') triggerEvent = 'StatusChange';
+          else if (sdkMsg.length > 0) {
+            // Non-standard SDK message = custom action bound to entity
+            triggerEvent = 'Action';
+            customActionName = String(rawSdkMsg);
+          } else if (triggerKind.includes('create')) triggerEvent = 'Create';
+          else if (triggerKind.includes('update')) triggerEvent = 'Update';
+          else if (triggerKind.includes('delete')) triggerEvent = 'Delete';
+          else {
+            // Log parameter keys and relevant values to aid future diagnosis
+            const params = trigger.inputs?.parameters ?? {};
+            const paramKeys = Object.keys(params);
+            debugLog('flow-parse', `Dataverse trigger event Unknown — param keys: [${paramKeys.join(', ')}]`, {
+              sdkmessagename: params['subscriptionRequest/sdkmessagename'],
+              catalog: params['catalog'],
+              category: params['category'],
+            });
+          }
         }
       }
 
-      // Entity extraction — try modern connector path first, then legacy paths
-      triggerEntity =
+      // Entity extraction — try modern connector path first, then legacy paths.
+      // Normalize 'none' (Dataverse sentinel for global/unbound trigger) to null.
+      const rawTriggerEntity =
         trigger.inputs?.parameters?.['subscriptionRequest/entityname'] ||
         trigger.inputs?.body?.EntityLogicalName ||
         trigger.inputs?.parameters?.EntityLogicalName ||
@@ -156,13 +203,24 @@ export class FlowDefinitionParser {
         trigger.inputs?.parameters?.entityLogicalName ||
         trigger.metadata?.entityName ||
         null;
+      triggerEntity = (rawTriggerEntity && String(rawTriggerEntity).toLowerCase() !== 'none')
+        ? String(rawTriggerEntity)
+        : null;
 
       if (triggerEntity === null) {
-        debugLog('flow-parse', 'Dataverse trigger — triggerEntity=null (all paths missed)', {
+        // "When an action is performed" trigger — entity is null (global custom action).
+        // Extract the custom action schema name so callers can label the source correctly.
+        const rawActionName =
+          trigger.inputs?.parameters?.['subscriptionRequest/catalog/actionname'] ||
+          trigger.inputs?.parameters?.['subscriptionRequest/actionname'] ||
+          null;
+        if (rawActionName && typeof rawActionName === 'string') {
+          customActionName = rawActionName;
+        }
+        debugLog('flow-parse', 'Dataverse trigger — triggerEntity=null', {
           triggerKind, apiId,
+          customActionName,
           parameters: trigger.inputs?.parameters,
-          body: trigger.inputs?.body,
-          metadata: trigger.metadata,
         });
       } else {
         debugLog('flow-parse', `Dataverse trigger — triggerEntity="${triggerEntity}"`, {
@@ -188,6 +246,31 @@ export class FlowDefinitionParser {
     } else if (triggerKind.includes('manual') || triggerKind.includes('request')) {
       triggerType = 'Manual';
       triggerEvent = 'Manual';
+
+      // Some manual flows are bound to an entity (e.g. MDA command bar flows).
+      // The entity type may appear in various places in the trigger inputs schema.
+      const schema = trigger.inputs?.schema?.properties;
+      const entityType =
+        schema?.body?.properties?.entity?.properties?.entityType?.default ||
+        schema?.entity?.properties?.entityType?.default ||
+        schema?.entity?.schema?.properties?.entityType?.default ||
+        trigger.inputs?.host?.schema?.properties?.entityLogicalName?.default ||
+        null;
+
+      if (entityType && typeof entityType === 'string' && entityType.toLowerCase() !== 'none') {
+        triggerEntity = entityType.toLowerCase();
+        debugLog('flow-parse', `Manual trigger — entity-bound triggerEntity="${triggerEntity}"`, {
+          resolvedFrom: schema?.body?.properties?.entity?.properties?.entityType?.default ? 'schema.body.entity.entityType' :
+            schema?.entity?.properties?.entityType?.default ? 'schema.entity.entityType' :
+            schema?.entity?.schema?.properties?.entityType?.default ? 'schema.entity.schema.entityType' :
+            'host.schema.entityLogicalName',
+        });
+      } else {
+        debugLog('flow-parse', `Manual trigger — no entity binding found`, {
+          schemaKeys: schema ? Object.keys(schema) : null,
+          hostKeys: trigger.inputs?.host ? Object.keys(trigger.inputs.host) : null,
+        });
+      }
     } else if (triggerKind.includes('recurrence') || triggerKind.includes('schedule')) {
       triggerType = 'Scheduled';
       triggerEvent = 'Scheduled';
@@ -199,7 +282,7 @@ export class FlowDefinitionParser {
       });
     }
 
-    return { type: triggerType, event: triggerEvent, entity: triggerEntity, conditions };
+    return { type: triggerType, event: triggerEvent, entity: triggerEntity, conditions, customActionName };
   }
 
   /**
@@ -395,12 +478,6 @@ export class FlowDefinitionParser {
     Object.keys(definition.actions).forEach((actionKey) => {
       processAction(definition.actions[actionKey], actionKey);
     });
-
-    debugLog('flow-parse', `extractDataverseActions: ${dataverseActions.length} action(s) found`,
-      dataverseActions.length > 0
-        ? dataverseActions.map(a => `${a.operation}→${a.targetEntity || '[unbound]'} (${a.confidence})`)
-        : undefined
-    );
 
     return dataverseActions;
   }

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1342,16 +1342,27 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     // Chain links table
     sections.push('## Chain Links');
     sections.push('');
-    const chainHeaders = ['Source Entity', 'Automation', 'Type', '→', 'Target Entity', 'Operation', 'Mode'];
-    const chainRows = analysis.chainLinks.map(l => [
-      l.sourceEntityDisplayName,
-      l.automationName,
-      l.automationType,
-      '→',
-      l.targetEntityDisplayName,
-      l.operation,
-      l.isAsynchronous ? 'Async' : 'Sync',
-    ]);
+    const chainHeaders = ['Source Trigger', 'Automation', 'Type', 'Trigger Operation', 'Mode', '→', 'Target Entity', 'Target Operation'];
+    const chainRows = analysis.chainLinks.map(l => {
+      const sourceTrigger = l.sourceEntity === '(custom-action)'
+        ? l.sourceEntityDisplayName.replace('Custom Action: ', '') + ' (Custom Action)'
+        : l.sourceEntity.startsWith('(') ? '(unbound)'
+        : `${l.sourceEntityDisplayName} (\`${l.sourceEntity}\`)`;
+      const triggerOp = l.triggerOperation === 'Action' && l.triggerCustomActionName
+        ? `Custom Action (${l.triggerCustomActionName})`
+        : l.triggerOperation === 'CreateOrUpdate' ? 'Create or Update'
+        : l.triggerOperation;
+      return [
+        sourceTrigger,
+        l.automationName,
+        l.automationType,
+        triggerOp,
+        l.isAsynchronous ? 'Async' : 'Sync',
+        '→',
+        l.targetEntity !== '(unbound)' ? `${l.targetEntityDisplayName} (\`${l.targetEntity}\`)` : 'Unbound',
+        l.operation,
+      ];
+    });
     sections.push(MarkdownFormatter.formatTable(chainHeaders, chainRows));
     sections.push('');
 
@@ -1422,7 +1433,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
             name: entryPoint.automationName,
             type: entryPoint.automationType,
             affectedEntities: [],
-            triggerType: entryPoint.isScheduled ? 'Scheduled' : entryPoint.isOnDemand ? 'Manual' : 'Dataverse',
+            triggerType: entryPoint.triggerOperation === 'Scheduled' ? 'Scheduled' : entryPoint.triggerOperation === 'Manual' ? 'Manual' : 'Dataverse',
             hasExternalCalls: false,
           });
         }
@@ -1508,12 +1519,12 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     lines.push(`<summary><strong>${entryPoint.automationName}</strong> (${entryPoint.automationType} — ${entryPoint.operation} from ${entryPoint.sourceEntityDisplayName})</summary>`);
     lines.push('');
     lines.push(`**Source:** ${entryPoint.sourceEntityDisplayName} (\`${entryPoint.sourceEntity}\`)`);
-    lines.push(`**Operation:** ${entryPoint.operation}`);
+    lines.push(`**Trigger Operation:** ${entryPoint.triggerOperation === 'CreateOrUpdate' ? 'Create or Update' : entryPoint.triggerOperation}`);
+    if (entryPoint.triggerCustomActionName) lines.push(`**Trigger Action:** \`${entryPoint.triggerCustomActionName}\``);
+    lines.push(`**Target Operation:** ${entryPoint.operation}`);
     lines.push(`**Type:** ${entryPoint.automationType}`);
     lines.push(`**Mode:** ${entryPoint.isAsynchronous ? 'Asynchronous' : 'Synchronous'}`);
     lines.push(`**Confidence:** ${entryPoint.confidence}`);
-    if (entryPoint.isScheduled) lines.push('**Scheduled:** Yes');
-    if (entryPoint.isOnDemand) lines.push('**On Demand:** Yes');
     if (entryPoint.fields.length > 0) {
       lines.push(`**Fields Set:** \`${entryPoint.fields.join('`, `')}\``);
     }

--- a/src/core/reporters/html/HtmlTemplates.ts
+++ b/src/core/reporters/html/HtmlTemplates.ts
@@ -1938,14 +1938,29 @@ ${rows}
       ${this.htmlPipelineTraces(analysis)}`;
 
     // Global Chain Map — matches the React UI "Global Chain Map" tab
-    const chainRows = analysis.chainLinks.map(l => `<tr>
-      <td>${this.htmlEscape(l.sourceEntityDisplayName)}<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.sourceEntity)}</small></td>
-      <td>${this.htmlEscape(l.automationName)}<br/><span class="badge badge-${l.automationType === 'Flow' ? 'success' : 'warning'}">${this.htmlEscape(l.automationType)}</span></td>
-      <td>→</td>
-      <td>${this.htmlEscape(l.targetEntityDisplayName)}<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.targetEntity)}</small></td>
-      <td><span class="badge badge-${l.operation === 'Create' ? 'success' : l.operation === 'Delete' ? 'danger' : 'warning'}">${this.htmlEscape(l.operation)}</span></td>
-      <td><span class="badge badge-${l.isAsynchronous ? 'success' : 'warning'}">${l.isAsynchronous ? 'Async' : 'Sync'}</span></td>
-    </tr>`).join('');
+    const chainRows = analysis.chainLinks.map(l => {
+      const sourceTriggerCell = l.sourceEntity === '(custom-action)'
+        ? `Custom Action<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.sourceEntityDisplayName.replace('Custom Action: ', ''))}</small>`
+        : l.sourceEntity.startsWith('(')
+        ? `<em style="color:#666">(unbound)</em>`
+        : `${this.htmlEscape(l.sourceEntityDisplayName)}<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.sourceEntity)}</small>`;
+      const triggerOpCell = l.triggerOperation === 'Action' && l.triggerCustomActionName
+        ? `Custom Action<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.triggerCustomActionName)}</small>`
+        : l.triggerOperation === 'CreateOrUpdate' ? 'Create or Update'
+        : this.htmlEscape(l.triggerOperation);
+      const targetCell = l.targetEntity !== '(unbound)'
+        ? `${this.htmlEscape(l.targetEntityDisplayName)}<br/><small style="font-family:monospace;color:#666">${this.htmlEscape(l.targetEntity)}</small>`
+        : `${this.htmlEscape(l.targetEntityDisplayName)}<br/><small style="font-family:monospace;color:#666;font-style:italic">No entity target</small>`;
+      return `<tr>
+        <td>${sourceTriggerCell}</td>
+        <td>${this.htmlEscape(l.automationName)}<br/><span class="badge badge-${l.automationType === 'Flow' ? 'success' : 'warning'}">${this.htmlEscape(l.automationType)}</span></td>
+        <td>${triggerOpCell}</td>
+        <td><span class="badge badge-${l.isAsynchronous ? 'success' : 'warning'}">${l.isAsynchronous ? 'Async' : 'Sync'}</span></td>
+        <td>→</td>
+        <td>${targetCell}</td>
+        <td><span class="badge badge-${l.operation === 'Create' ? 'success' : l.operation === 'Delete' ? 'danger' : 'warning'}">${this.htmlEscape(l.operation)}</span></td>
+      </tr>`;
+    }).join('');
     const globalChainHtml = analysis.chainLinks.length > 0 ? `
       <h3>Global Chain Map (${analysis.chainLinks.length})</h3>
       <p style="color:#666;margin-bottom:12px;">All detected cross-entity write operations. Synchronous operations may impact performance.</p>
@@ -1953,12 +1968,13 @@ ${rows}
         <table class="data-table sortable" id="cross-entity-table">
           <thead>
             <tr>
-              <th scope="col" onclick="sortTable('cross-entity-table', 0)">Source Entity <span class="sort-indicator"></span></th>
+              <th scope="col" onclick="sortTable('cross-entity-table', 0)">Source Trigger <span class="sort-indicator"></span></th>
               <th scope="col" onclick="sortTable('cross-entity-table', 1)">Automation <span class="sort-indicator"></span></th>
-              <th scope="col"></th>
-              <th scope="col" onclick="sortTable('cross-entity-table', 3)">Target Entity <span class="sort-indicator"></span></th>
-              <th scope="col" onclick="sortTable('cross-entity-table', 4)">Operation <span class="sort-indicator"></span></th>
+              <th scope="col" onclick="sortTable('cross-entity-table', 2)">Trigger Operation <span class="sort-indicator"></span></th>
               <th scope="col">Mode</th>
+              <th scope="col"></th>
+              <th scope="col" onclick="sortTable('cross-entity-table', 5)">Target Entity <span class="sort-indicator"></span></th>
+              <th scope="col" onclick="sortTable('cross-entity-table', 6)">Target Operation <span class="sort-indicator"></span></th>
             </tr>
           </thead>
           <tbody>${chainRows}</tbody>
@@ -2045,7 +2061,7 @@ ${rows}
             name: entryPoint.automationName,
             type: entryPoint.automationType,
             affectedEntities: [],
-            triggerType: entryPoint.isScheduled ? 'Scheduled' : entryPoint.isOnDemand ? 'Manual' : 'Dataverse',
+            triggerType: entryPoint.triggerOperation === 'Scheduled' ? 'Scheduled' : entryPoint.triggerOperation === 'Manual' ? 'Manual' : 'Dataverse',
             hasExternalCalls: false,
           });
         }

--- a/src/core/types/blueprint.ts
+++ b/src/core/types/blueprint.ts
@@ -247,7 +247,11 @@ export interface FlowDefinition {
   triggerEvent: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Assign' | 'Grant' | 'Revoke' | 'StatusChange' | 'Action' | 'Manual' | 'Scheduled' | 'Unknown';
   triggerEntity: string | null;
   triggerConditions: string | null;
-  /** Dataverse custom action schema name when triggered by "When an action is performed" with no entity binding */
+  /**
+   * Dataverse custom action / SDK message name for custom action triggers.
+   * Set when the flow is triggered by a global "When an action is performed" (no entity binding),
+   * or by an entity-bound custom action detected via a non-standard sdkmessagename.
+   */
   triggerCustomActionName?: string;
   scopeType: 'User' | 'BusinessUnit' | 'Organization' | 'Unknown';
   actionsCount: number;

--- a/src/core/types/blueprint.ts
+++ b/src/core/types/blueprint.ts
@@ -244,9 +244,11 @@ export interface Flow {
  */
 export interface FlowDefinition {
   triggerType: 'Dataverse' | 'Manual' | 'Scheduled' | 'Other';
-  triggerEvent: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Manual' | 'Scheduled' | 'Unknown';
+  triggerEvent: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Assign' | 'Grant' | 'Revoke' | 'StatusChange' | 'Action' | 'Manual' | 'Scheduled' | 'Unknown';
   triggerEntity: string | null;
   triggerConditions: string | null;
+  /** Dataverse custom action schema name when triggered by "When an action is performed" with no entity binding */
+  triggerCustomActionName?: string;
   scopeType: 'User' | 'BusinessUnit' | 'Organization' | 'Unknown';
   actionsCount: number;
   externalCalls: ExternalCall[];

--- a/src/core/types/crossEntityTrace.ts
+++ b/src/core/types/crossEntityTrace.ts
@@ -26,7 +26,7 @@ export interface CrossEntityEntryPoint {
   /** For on-demand classic workflows */
   isOnDemand: boolean;
   confidence: 'High' | 'Medium' | 'Low';
-  /** What event triggers this automation (Create/Update/Delete/Manual/Scheduled/Action) */
+  /** What event triggers this automation (Create/Update/Delete/CreateOrUpdate/Assign/Grant/Revoke/StatusChange/Manual/Scheduled/Action/Unknown) */
   triggerOperation: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Assign' | 'Grant' | 'Revoke' | 'StatusChange' | 'Manual' | 'Scheduled' | 'Action' | 'Unknown';
   /** Custom action / SDK message name when triggerOperation is 'Action' */
   triggerCustomActionName?: string;

--- a/src/core/types/crossEntityTrace.ts
+++ b/src/core/types/crossEntityTrace.ts
@@ -26,6 +26,10 @@ export interface CrossEntityEntryPoint {
   /** For on-demand classic workflows */
   isOnDemand: boolean;
   confidence: 'High' | 'Medium' | 'Low';
+  /** What event triggers this automation (Create/Update/Delete/Manual/Scheduled/Action) */
+  triggerOperation: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Assign' | 'Grant' | 'Revoke' | 'StatusChange' | 'Manual' | 'Scheduled' | 'Action' | 'Unknown';
+  /** Custom action / SDK message name when triggerOperation is 'Action' */
+  triggerCustomActionName?: string;
   /**
    * For 'Action' operations: the Dataverse custom action / bound API unique name.
    * Internal effects on the target entity are unknown — shown in chain with informational note.
@@ -152,6 +156,11 @@ export interface CrossEntityChainLink {
   targetEntityDisplayName: string;
   automationName: string;
   automationType: 'Flow' | 'ClassicWorkflow';
+  /** What event triggers this automation */
+  triggerOperation: 'Create' | 'Update' | 'Delete' | 'CreateOrUpdate' | 'Assign' | 'Grant' | 'Revoke' | 'StatusChange' | 'Manual' | 'Scheduled' | 'Action' | 'Unknown';
+  /** Custom action / SDK message name when triggerOperation is 'Action' */
+  triggerCustomActionName?: string;
+  /** What the automation does to the target entity */
   operation: 'Create' | 'Update' | 'Delete' | 'Action';
   isAsynchronous: boolean;
   /**


### PR DESCRIPTION
 ---
  Summary

  - Extends Dataverse trigger detection in the flow parser to handle message codes 5 (Assign), 6 (Grant), 7 (Revoke), 8 (StatusChange), plus a sdkmessagename string fallback. Non-standard SDK message names are now correctly identified as entity-bound custom action
  triggers instead of falling through to Unknown.
  - Adds triggerOperation and triggerCustomActionName fields to CrossEntityEntryPoint and CrossEntityChainLink, propagated through the full analyzer pipeline including child flow chains.
  - Redesigns the Global Chain Map table: Source Trigger | Automation | Trigger Operation | Mode | → | Target Entity | Target Operation. Custom action trigger names appear as a secondary mono line in the Trigger Operation column.
  - Updates HTML and Markdown exports to match the new column layout.
  - Moves all inline style={{ color: tokens.* }} props in GlobalChainMapPanel to makeStyles for correct dark-theme rendering.
  - Removes all diagnostic debugLog calls from flow parse, discovery, and cross-entity analyzer.

  Test plan

  - Open a solution that includes flows triggered by Assign, Grant, Revoke, or StatusChange — verify correct Trigger Operation labels appear in the chain map
  - Open a solution containing a flow triggered by an entity-bound custom action (non-standard sdkmessagename) — verify "Custom Action" label with action name shown as mono secondary line; no Unknown in Trigger Operation
  - Verify child flows inherit triggerOperation and triggerCustomActionName from their parent
  - Switch to dark theme — verify all muted/secondary text in the chain map is visible
  - Export as HTML and Markdown — verify chain map table has the correct 7-column layout with Trigger Operation column
  - Verify no [PPSB:flow-parse] or [PPSB:flow-scope] debug output appears in browser console