### PR TITLE
Chore/update agent models

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Senior solution architect for PPSB. Invoke for architecture decisions, Dataverse API design, TypeScript interface design, security architecture, React component architecture, performance strategy, and any decision that will be hard to reverse. Only ONE architect instance should be active at any time. Do not invoke for routine implementation tasks — use the developer agent instead.
-model: claude-opus-4-6
+model: claude-opus-4-8
 tools: Read, Glob, Grep, WebFetch, WebSearch, Write
 ---
 

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,7 +1,7 @@
 ---
 name: developer
 description: Senior Tech Lead developer for PPSB. Invoke for all implementation work — new features, bug fixes, refactoring, component creation, Dataverse API integration, TypeScript type work, and build/tooling changes. Works from architectural decisions already made. Does not make architectural decisions — escalates to architect if needed.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch
 ---
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
 description: ALWAYS start here. The orchestrator coordinates all work on the Power Platform Solution Blueprint (PPSB) project. Invoke this agent first for any new task, feature, bug, refactor, or question. It reads project memory, decides which specialist agent to delegate to, and ensures only one architect instance is active. Do not invoke other agents directly — let the orchestrator decide.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 tools: Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch
 ---
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Senior code reviewer for PPSB. Invoke after implementation is complete, before any commit or merge. Reviews for TypeScript correctness, React patterns, Fluent UI v9 compliance, Dataverse API safety, security vulnerabilities, and adherence to established project patterns. Read-only — never modifies files directly.
-model: claude-haiku-4-5-20251001
+model: claude-sonnet-5
 tools: Read, Glob, Grep, WebFetch
 ---
 

--- a/.claude/memory/patterns-dataverse.md
+++ b/.claude/memory/patterns-dataverse.md
@@ -217,7 +217,7 @@ await window.dataverseAPI.queryData('entities');
 
 Every commit MUST:
 1. Use Conventional Commits format: `<type>[optional scope]: <description>`
-2. End with `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+2. End with `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`
 3. Be a separate commit per logical change — never batch unrelated changes
 
 **Types:** feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert

--- a/.claude/memory/patterns-dataverse.md
+++ b/.claude/memory/patterns-dataverse.md
@@ -217,7 +217,7 @@ await window.dataverseAPI.queryData('entities');
 
 Every commit MUST:
 1. Use Conventional Commits format: `<type>[optional scope]: <description>`
-2. End with `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`
+2. End with `Co-Authored-By: Claude <noreply@anthropic.com>`
 3. Be a separate commit per logical change — never batch unrelated changes
 
 **Types:** feat, fix, docs, style, refactor, perf, test, chore, build, ci, revert

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,10 @@ Report: **"Memory loaded: [files read]"**
 
 | Agent | Model | Role |
 |-------|-------|------|
-| `orchestrator` | Sonnet 4.6 | Routes all tasks; start every session here |
-| `architect` | Opus 4.6 | Architecture decisions and data model design; only ONE active at a time |
-| `developer` | Sonnet 4.6 | All implementation — features, bugs, components, Dataverse integration |
-| `reviewer` | Haiku 4.5 | Read-only code review for TypeScript, React, Fluent UI v9, and security |
+| `orchestrator` | Sonnet 5 | Routes all tasks; start every session here |
+| `architect` | Opus 4.8 | Architecture decisions and data model design; only ONE active at a time |
+| `developer` | Sonnet 5 | All implementation — features, bugs, components, Dataverse integration |
+| `reviewer` | Sonnet 5 | Read-only code review for TypeScript, React, Fluent UI v9, and security |
 | `document-updater` | Haiku 4.5 | CHANGELOG, docs/, README, and memory file maintenance |
 | `skills-learner` | Haiku 4.5 | Captures corrections and feedback into memory files |
 | `security-auditor` | Haiku 4.5 | Read-only security scan before any commit, push, or release |
@@ -94,7 +94,7 @@ Report: **"Memory loaded: [files read]"**
 - **NEVER** use `executeDataverseRequest()` or `window.toolboxAPI.dataverse.*` — they do not exist → see PATTERN-005
 - **ALWAYS** use static imports for reporters — dynamic imports break under `pptb-webview://` → see PATTERN-007
 - **ALWAYS** commit one logical change per commit, Conventional Commits format, with trailer:
-  `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` → see PATTERN-011
+  `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` → see PATTERN-011
 - **ALWAYS** run `pnpm typecheck && pnpm build` after any code change before committing — typecheck alone is not sufficient
 - **ALWAYS** run `/pre-commit` before any git commit. Run `/push-branch` instead of `git push` directly — it runs the full pre-PR gate and only pushes if clean.
 - **ALWAYS** check `src/core/utils/` and `src/hooks/` before writing any new utility logic — see patterns-general.md D1–D6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Report: **"Memory loaded: [files read]"**
 - **NEVER** use `executeDataverseRequest()` or `window.toolboxAPI.dataverse.*` — they do not exist → see PATTERN-005
 - **ALWAYS** use static imports for reporters — dynamic imports break under `pptb-webview://` → see PATTERN-007
 - **ALWAYS** commit one logical change per commit, Conventional Commits format, with trailer:
-  `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` → see PATTERN-011
+  `Co-Authored-By: Claude <noreply@anthropic.com>` → see PATTERN-011
 - **ALWAYS** run `pnpm typecheck && pnpm build` after any code change before committing — typecheck alone is not sufficient
 - **ALWAYS** run `/pre-commit` before any git commit. Run `/push-branch` instead of `git push` directly — it runs the full pre-PR gate and only pushes if clean.
 - **ALWAYS** check `src/core/utils/` and `src/hooks/` before writing any new utility logic — see patterns-general.md D1–D6


### PR DESCRIPTION
This pull request updates the Claude agent models used across the project to their latest available versions and standardizes the commit co-author trailer. These changes ensure the team is leveraging the most up-to-date AI capabilities and maintains consistency in commit metadata.

**Agent Model Upgrades:**

* Upgraded the `orchestrator` and `developer` agents from `claude-sonnet-4-6` to `claude-sonnet-5`, and the `reviewer` agent from `claude-haiku-4-5-20251001` to `claude-sonnet-5` in their respective configuration files (`.claude/agents/orchestrator.md`, `.claude/agents/developer.md`, `.claude/agents/reviewer.md`). [[1]](diffhunk://#diff-9424fd6190072adea1cd92d1d977577eb0ed1e4834754d8a3b771cf71a1a8a04L4-R4) [[2]](diffhunk://#diff-c4237a499b1a006c16a8bf1bb112c36c0daf8c1752ef71f1bcf10f604bb0f357L4-R4) [[3]](diffhunk://#diff-d704f8e5cb46043ca9d510b13d64789cf70229324bd30a2ba49a843577483a4aL4-R4)
* Updated the `architect` agent from `claude-opus-4-6` to `claude-opus-4-8` in `.claude/agents/architect.md`.
* Reflected these model changes in the agent summary table in `CLAUDE.md`.

**Commit Metadata Standardization:**

* Updated the required commit trailer to use `Co-Authored-By: Claude <noreply@anthropic.com>` instead of the previous version-specific address in both `.claude/memory/patterns-dataverse.md` and `CLAUDE.md`. [[1]](diffhunk://#diff-cde0e4a0b369ac685c0caa351d0db0ddc17e0aa31f93de632b2e829f48ef3074L220-R220) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L97-R97)