### PR TITLE
feat/ai friendly markdown export

### DIFF
--- a/.claude/memory/learnings.md
+++ b/.claude/memory/learnings.md
@@ -170,24 +170,21 @@ Promoted → AUDIT-006 in patterns-ui.md ([2026-03-14])
 
 ---
 
-## [2026-02-26, updated 2026-03-13] — Version numbers in five files must always match at release time
+## [2026-02-26, updated 2026-03-13, resolved 2026-07-01] — Version numbers in five files must always match at release time
 
 **Affects:** Document Updater, Orchestrator, Reviewer
 **Severity:** Blocker
-**Rule:** Version numbers appear in five places that must all match before a release is tagged:
+**Rule:** Version numbers appear in four places that must all match before a release is tagged:
 1. `package.json` — the `"version"` field
 2. `CHANGELOG.md` — the latest versioned entry header (e.g. `## [1.1.0] — 2026-03-12`)
 3. `README.md` — the shields.io version badge at the top and any inline version references
-4. `src/core/reporters/JsonReporter.ts` — the `private readonly toolVersion` field (line ~24). This is hardcoded and is NOT derived from `package.json`. It must be manually updated on every release.
-5. `docs/user-guide.md` — the version string in the subtitle on line 3 (e.g. `Complete guide for using Power Platform Solution Blueprint (PPSB) v1.1.0`)
+4. `docs/user-guide.md` — the version string in the subtitle on line 3 (e.g. `Complete guide for using Power Platform Solution Blueprint (PPSB) v1.1.0`)
 
-The Document Updater must update all five in the same release step. Mismatched versions across any of these files is a release blocker and must be resolved before the orchestrator prints the git tag command.
-**Context:** (1–3) Added 2026-02-26 after noticing the README badge was missing from the release workflow. (4–5) Added 2026-03-13: `JsonReporter.ts` contains a hardcoded `toolVersion` class field that agents repeatedly overlooked at release time; `docs/user-guide.md` line 3 subtitle also embeds the version string and was equally overlooked.
+The Document Updater must update all four in the same release step. Mismatched versions across any of these files is a release blocker and must be resolved before the orchestrator prints the git tag command.
+**Context:** (1–3) Added 2026-02-26 after noticing the README badge was missing from the release workflow. (4) Added 2026-03-13 as a fifth location (`JsonReporter.ts` with hardcoded `toolVersion` field), but this was resolved in the `feat/ai-friendly-markdown-export` branch on 2026-07-01. Both `MarkdownReporter.ts` and `JsonReporter.ts` now import `version` from `package.json`, eliminating the need to manually update a hardcoded field. The hardcoded field entry is therefore **REMOVED** and the four-file rule remains.
 **Example:**
-- Wrong: Bumping `package.json` to `1.2.0` and updating `CHANGELOG.md` and `README.md` but leaving `JsonReporter.ts` on `1.1.0` and `docs/user-guide.md` subtitle on `v1.1.0`
-- Right: Update all five files in the same step; verify every location reads the new version before proceeding
-- ❌ Wrong: `private readonly toolVersion = '1.1.0';` after bumping the project to `1.2.0`
-- ✅ Right: `private readonly toolVersion = '1.2.0';` — updated in the same commit as `package.json`
+- Wrong: Bumping `package.json` to `1.2.0` and updating `CHANGELOG.md` and `README.md` but leaving `docs/user-guide.md` subtitle on `v1.1.0`
+- Right: Update all four files in the same step; verify every location reads the new version before proceeding
 
 ---
 

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -20,15 +20,14 @@
 
 **v1.3.0** (released 2026-06-23) — minor: 12 new component types, reverse solution lookup (#40), cascade configuration in exports (#42), business rule parser improvements (#37)
 
-**In progress:** `feat/ai-friendly-markdown-export` branch — 8 commits pushed to GitHub
-- YAML frontmatter (46 files with blueprint_type, metadata, version)
+**v1.4.0** (pending merge — `feat/ai-friendly-markdown-export` PR open)
+- YAML frontmatter on all generated Markdown files (blueprint_type, metadata, version)
 - Entity overview description blockquote
 - Flat headings in cross-entity trace (replaces `<details>`/`<summary>`)
 - `MarkdownFormatter.formatFrontmatter()` and `formatBlockquote()` helpers
 - `extractPublisherPrefix` refactored into `src/core/utils/entityName.ts`
-- YAML escaping fixes (newlines, arrays, backslashes)
+- YAML escaping fixes (newlines, arrays, backslashes, YAML literals, non-string array items)
 - Version import pattern unified across MarkdownReporter and JsonReporter
-- PR not yet opened
 
 **v1.1.2** (released 2026-03-17) — patch: cross-entity chain map redesign (trigger operation column, message code support), debug logging cleanup
 **v1.1.1** (released 2026-03-17) — patch: business rules IF/THEN/ELSE, conditionCount fix, DRY/SOLID refactoring, debug logger, Custom APIs click fix, env vars eye icon fix, CDS Default Solution filter fix, HTML cross-entity structure fix

--- a/.claude/memory/project.md
+++ b/.claude/memory/project.md
@@ -1,6 +1,6 @@
 # PPSB Project State
 
-**Last updated:** 2026-03-17
+**Last updated:** 2026-07-01
 
 ---
 
@@ -18,7 +18,18 @@
 
 ## Current Version
 
-**v1.3.0** (pending release 2026-06-23) — minor: 12 new component types, reverse solution lookup (#40), cascade configuration in exports (#42), business rule parser improvements (#37)
+**v1.3.0** (released 2026-06-23) — minor: 12 new component types, reverse solution lookup (#40), cascade configuration in exports (#42), business rule parser improvements (#37)
+
+**In progress:** `feat/ai-friendly-markdown-export` branch — 8 commits pushed to GitHub
+- YAML frontmatter (46 files with blueprint_type, metadata, version)
+- Entity overview description blockquote
+- Flat headings in cross-entity trace (replaces `<details>`/`<summary>`)
+- `MarkdownFormatter.formatFrontmatter()` and `formatBlockquote()` helpers
+- `extractPublisherPrefix` refactored into `src/core/utils/entityName.ts`
+- YAML escaping fixes (newlines, arrays, backslashes)
+- Version import pattern unified across MarkdownReporter and JsonReporter
+- PR not yet opened
+
 **v1.1.2** (released 2026-03-17) — patch: cross-entity chain map redesign (trigger operation column, message code support), debug logging cleanup
 **v1.1.1** (released 2026-03-17) — patch: business rules IF/THEN/ELSE, conditionCount fix, DRY/SOLID refactoring, debug logger, Custom APIs click fix, env vars eye icon fix, CDS Default Solution filter fix, HTML cross-entity structure fix
 **v1.1.0** (released 2026-03-12) — minor: pipeline-first Cross-Entity Automation view, external API call detection, HTML/Markdown export parity, and AUDIT compliance fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Power Platform Solution Blueprint will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] — 2026-07-01
 
 ### Added
 - **AI-friendly Markdown export — YAML frontmatter and flat headings** — all 46 generated Markdown files now include YAML frontmatter blocks with metadata (`blueprint_type`, logical name, display name, counts, version); entity overview sections include Dataverse description as blockquote for self-contained AI agent reading; cross-entity trace sections replace `<details>`/`<summary>` HTML collapsed blocks with flat `###` headings so content is visible to AI agents and rendered expanded in ADO Wiki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.4.0] — 2026-07-01
 
 ### Added
-- **AI-friendly Markdown export — YAML frontmatter and flat headings** — all 46 generated Markdown files now include YAML frontmatter blocks with metadata (`blueprint_type`, logical name, display name, counts, version); entity overview sections include Dataverse description as blockquote for self-contained AI agent reading; cross-entity trace sections replace `<details>`/`<summary>` HTML collapsed blocks with flat `###` headings so content is visible to AI agents and rendered expanded in ADO Wiki
+- **AI-friendly Markdown export — YAML frontmatter and flat headings** — all generated Markdown files now include YAML frontmatter blocks with metadata (`blueprint_type`, logical name, display name, counts, version); entity overview sections include Dataverse description as blockquote for self-contained AI agent reading; cross-entity trace sections replace `<details>`/`<summary>` HTML collapsed blocks with flat `###` headings so content is visible to AI agents and rendered expanded in ADO Wiki
 
 ### Changed
 - **Markdown export headings in cross-entity trace** — replaced `<details>`/`<summary>` HTML collapsed sections with flat `###` headings (H3) for improved readability in AI agents and Azure DevOps Wiki rendering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Power Platform Solution Blueprint will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **AI-friendly Markdown export — YAML frontmatter and flat headings** — all 46 generated Markdown files now include YAML frontmatter blocks with metadata (`blueprint_type`, logical name, display name, counts, version); entity overview sections include Dataverse description as blockquote for self-contained AI agent reading; cross-entity trace sections replace `<details>`/`<summary>` HTML collapsed blocks with flat `###` headings so content is visible to AI agents and rendered expanded in ADO Wiki
+
+### Changed
+- **Markdown export headings in cross-entity trace** — replaced `<details>`/`<summary>` HTML collapsed sections with flat `###` headings (H3) for improved readability in AI agents and Azure DevOps Wiki rendering
+
+### Technical
+- **MarkdownFormatter new static helpers** — `formatFrontmatter(fields)` generates YAML with proper escaping (string quoting for colons/hashes/newlines, YAML 1.1 literal detection, array flow sequences with per-item escaping); `formatBlockquote(text)` handles multi-line blockquotes with proper indentation
+- **`extractPublisherPrefix` refactoring** — moved 4th duplicate into `src/core/utils/entityName.ts` as named export; `MarkdownReporter.ts` imports it; pre-existing duplicates in `ERDGenerator.ts` and `SolutionDistributionAnalyzer.ts` tracked for follow-up consolidation
+- **Version import consolidation** — both `MarkdownReporter.ts` and `JsonReporter.ts` now import `version` from `package.json` (matching pattern)
+
+---
+
 ## [1.3.0] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Complete architectural blueprints for your Power Platform solutions.
 
-![Version](https://img.shields.io/badge/version-1.1.2-blue)
+![Version](https://img.shields.io/badge/version-1.4.0-blue)
 ![Status](https://img.shields.io/badge/status-stable-green)
 
 Generate comprehensive technical documentation for Dataverse and Power Platform solutions with automated discovery, analysis, and export capabilities.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # PPSB User Guide
 
-Complete guide for using Power Platform Solution Blueprint (PPSB) v1.3.0
+Complete guide for using Power Platform Solution Blueprint (PPSB) v1.4.0
 
 ## Table of Contents
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@sabrish/power-platform-solution-blueprint",
-  "version": "1.1.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sabrish/power-platform-solution-blueprint",
-      "version": "1.1.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-components": "^9.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabrish/power-platform-solution-blueprint",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "displayName": "Power Platform Solution Blueprint Generator",
   "description": "Generate comprehensive technical documentation for Dataverse and Power Platform solutions with automated discovery, analysis, and export capabilities.",
   "main": "index.html",

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -178,7 +178,7 @@ export function ExportDialog({ isOpen, result, onClose }: ExportDialogProps) {
                     />
                   </div>
                   <div className={styles.formatDescription}>
-                    Complete file structure - ideal for Azure DevOps Wiki
+                    Complete file structure - ideal for Azure DevOps Wiki and AI agents
                   </div>
                   <div className={styles.formatPreview}>
                     ~{estimatedFiles} files, {formatBytes(estimates.markdown)}

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1643,8 +1643,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const lines: string[] = [];
     const { entryPoint, activations, risks } = trace;
 
-    lines.push(`<details>`);
-    lines.push(`<summary><strong>${entryPoint.automationName}</strong> (${entryPoint.automationType} — ${entryPoint.operation} from ${entryPoint.sourceEntityDisplayName})</summary>`);
+    lines.push(`### ${entryPoint.automationName} _(${entryPoint.automationType} — ${entryPoint.operation} from ${entryPoint.sourceEntityDisplayName})_`);
     lines.push('');
     lines.push(`**Source:** ${entryPoint.sourceEntityDisplayName} (\`${entryPoint.sourceEntity}\`)`);
     lines.push(`**Trigger Operation:** ${entryPoint.triggerOperation === 'CreateOrUpdate' ? 'Create or Update' : entryPoint.triggerOperation}`);
@@ -1696,7 +1695,6 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
       lines.push('');
     }
 
-    lines.push('</details>');
     lines.push('');
 
     return lines.join('\n');

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1799,6 +1799,13 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Overview`, 1));
     sections.push('');
 
+    // Entity description
+    const entityDescription = meta.Description?.UserLocalizedLabel?.Label;
+    if (entityDescription && entityDescription.trim()) {
+      sections.push(`> ${entityDescription}`);
+      sections.push('');
+    }
+
     // Quick stats card
     sections.push(MarkdownFormatter.formatHeading('Quick Stats', 2));
     sections.push('');

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -42,6 +42,7 @@ import type { View } from '../types/view.js';
 import type { Dialog } from '../types/dialog.js';
 import type { AiModel } from '../types/aiModel.js';
 import type { VirtualTableDataSource } from '../types/virtualTableDataSource.js';
+import { version } from '../../../package.json';
 import { MarkdownFormatter } from './markdown/MarkdownFormatter.js';
 import {
   groupPluginsByAssembly,
@@ -56,6 +57,8 @@ import { calculateComplexityScore } from '../utils/complexity.js';
 import type { IReporter } from './IReporter.js';
 
 export class MarkdownReporter implements IReporter<MarkdownExport> {
+  private readonly toolVersion = version;
+
   /**
    * Generate complete markdown export from blueprint result
    */
@@ -213,6 +216,22 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateReadme(result: BlueprintResult): string {
     const sections: string[] = [];
+
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'blueprint_readme',
+      environment_url: result.metadata.environment,
+      generated_at: result.metadata.generatedAt.toISOString(),
+      tool_version: this.toolVersion,
+      scope_type: result.metadata.scope.type,
+      solution_names: result.metadata.solutionNames ?? [],
+      total_entities: result.summary.totalEntities,
+      total_plugins: result.summary.totalPlugins,
+      total_flows: result.summary.totalFlows,
+      total_business_rules: result.summary.totalBusinessRules,
+      total_classic_workflows: result.summary.totalClassicWorkflows,
+      total_web_resources: result.summary.totalWebResources,
+      total_security_roles: result.summary.totalSecurityRoles,
+    }));
 
     // Title and metadata
     sections.push(MarkdownFormatter.formatHeading('Power Platform Solution Blueprint', 1));
@@ -559,6 +578,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateMetrics(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({ blueprint_type: 'summary_metrics' }));
     sections.push(MarkdownFormatter.formatHeading('Blueprint Metrics & Statistics', 1));
     sections.push('');
 
@@ -647,6 +667,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllPlugins(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'plugin',
+      item_count: result.plugins.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Plugins', 1));
     sections.push('');
     sections.push(`**Total Plugins:** ${result.summary.totalPlugins}`);
@@ -720,6 +745,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllFlows(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'flow',
+      item_count: result.flows.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Cloud Flows', 1));
     sections.push('');
     sections.push(`**Total Flows:** ${result.summary.totalFlows}`);
@@ -763,6 +793,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllBusinessRules(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'business_rule',
+      item_count: result.businessRules.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Business Rules', 1));
     sections.push('');
     sections.push(`**Total Business Rules:** ${result.summary.totalBusinessRules}`);
@@ -867,6 +902,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllClassicWorkflows(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'classic_workflow',
+      item_count: result.classicWorkflows.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Classic Workflows', 1));
     sections.push('');
     sections.push('⚠️ **Classic workflows are legacy technology. Microsoft recommends creating new automation with Power Automate and migrating existing workflows.** [Learn more](https://learn.microsoft.com/en-us/power-automate/replace-workflows-with-flows)');
@@ -916,6 +956,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllWebResources(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'web_resource',
+      item_count: result.webResources.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Web Resources', 1));
     sections.push('');
     sections.push(`**Total Web Resources:** ${result.summary.totalWebResources}`);
@@ -974,6 +1019,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllCustomAPIs(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'custom_api',
+      item_count: result.customAPIs.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Custom APIs', 1));
     sections.push('');
     sections.push(`**Total Custom APIs:** ${result.summary.totalCustomAPIs}`);
@@ -1047,6 +1097,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllEnvironmentVariables(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'environment_variable',
+      item_count: result.environmentVariables.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Environment Variables', 1));
     sections.push('');
     sections.push(`**Total Environment Variables:** ${result.summary.totalEnvironmentVariables}`);
@@ -1089,6 +1144,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllConnectionReferences(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'connection_reference',
+      item_count: result.connectionReferences.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Connection References', 1));
     sections.push('');
     sections.push(`**Total Connection References:** ${result.summary.totalConnectionReferences}`);
@@ -1119,6 +1179,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllGlobalChoices(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'global_choice',
+      item_count: result.globalChoices.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Global Choices', 1));
     sections.push('');
     sections.push(`**Total Global Choices:** ${result.summary.totalGlobalChoices}`);
@@ -1151,6 +1216,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllCustomConnectors(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'custom_connector',
+      item_count: result.customConnectors.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Custom Connectors', 1));
     sections.push('');
     sections.push(`**Total Custom Connectors:** ${result.summary.totalCustomConnectors}`);
@@ -1182,6 +1252,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllBusinessProcessFlows(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'business_process_flow',
+      item_count: result.businessProcessFlows.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Business Process Flows', 1));
     sections.push('');
     sections.push(`**Total Business Process Flows:** ${result.summary.totalBusinessProcessFlows}`);
@@ -1242,6 +1317,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateExternalIntegrations(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'summary_external_integrations',
+      endpoint_count: result.externalEndpoints?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('External Integrations', 1));
     sections.push('');
 
@@ -1289,6 +1368,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const sections: string[] = [];
     const analysis = result.crossEntityAnalysis;
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'summary_cross_entity_automation',
+      entry_point_count: analysis?.totalEntryPoints ?? 0,
+      target_entity_count: analysis?.entityViews.size ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Cross-Entity Automation', 1));
     sections.push('');
 
@@ -1534,6 +1618,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const sections: string[] = [];
     const displayName = blueprint.entity.DisplayName?.UserLocalizedLabel?.Label || blueprint.entity.LogicalName;
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_cross_entity_trace',
+      logical_name: blueprint.entity.LogicalName,
+      display_name: displayName,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`Cross-Entity Trace — ${displayName}`, 1));
     sections.push('');
     sections.push(`**Entity:** \`${blueprint.entity.LogicalName}\``);
@@ -1632,6 +1721,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateSolutionDistribution(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'summary_solution_distribution',
+      solution_count: result.solutionDistribution?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Solution Distribution', 1));
     sections.push('');
 
@@ -1686,7 +1779,23 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const sections: string[] = [];
     const meta = entity.entity;
     const displayName = meta.DisplayName?.UserLocalizedLabel?.Label || meta.LogicalName;
+    const complexityScore = calculateComplexityScore(entity, result);
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_overview',
+      logical_name: meta.LogicalName,
+      display_name: displayName,
+      schema_name: meta.SchemaName,
+      publisher_prefix: this.extractPublisherPrefix(meta.SchemaName),
+      is_custom: !!meta.IsCustomEntity,
+      is_managed: !!meta.IsManaged,
+      complexity: complexityScore.level,
+      field_count: meta.Attributes?.length ?? 0,
+      plugin_count: entity.plugins.length,
+      flow_count: entity.flows.length,
+      business_rule_count: entity.businessRules.length,
+      solution_names: entity.referencingSolutions ?? [],
+    }));
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Overview`, 1));
     sections.push('');
 
@@ -1743,6 +1852,12 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const meta = entity.entity;
     const displayName = meta.DisplayName?.UserLocalizedLabel?.Label || meta.LogicalName;
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_schema',
+      logical_name: meta.LogicalName,
+      display_name: displayName,
+      attribute_count: meta.Attributes?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Schema`, 1));
     sections.push('');
 
@@ -1948,7 +2063,17 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const sections: string[] = [];
     const meta = entity.entity;
     const displayName = meta.DisplayName?.UserLocalizedLabel?.Label || meta.LogicalName;
+    const classicWorkflows = result.classicWorkflowsByEntity.get(meta.LogicalName) || [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_automation',
+      logical_name: meta.LogicalName,
+      display_name: displayName,
+      plugin_count: entity.plugins.length,
+      flow_count: entity.flows.length,
+      business_rule_count: entity.businessRules.length,
+      classic_workflow_count: classicWorkflows.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Automation`, 1));
     sections.push('');
 
@@ -2036,7 +2161,6 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     }
 
     // Classic workflows
-    const classicWorkflows = result.classicWorkflowsByEntity.get(meta.LogicalName) || [];
     if (classicWorkflows.length > 0) {
       sections.push(MarkdownFormatter.formatHeading('Classic Workflows (Deprecated)', 2));
       sections.push('');
@@ -2067,6 +2191,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const meta = entity.entity;
     const displayName = meta.DisplayName?.UserLocalizedLabel?.Label || meta.LogicalName;
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_execution_pipeline',
+      logical_name: meta.LogicalName,
+      display_name: displayName,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Execution Pipeline`, 1));
     sections.push('');
     sections.push('This page shows the execution order of server-side automation on this entity.');
@@ -2301,6 +2430,12 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     const meta = entity.entity;
     const displayName = meta.DisplayName?.UserLocalizedLabel?.Label || meta.LogicalName;
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'entity_business_process_flows',
+      logical_name: meta.LogicalName,
+      display_name: displayName,
+      bpf_count: bpfs.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`${displayName} - Business Process Flows`, 1));
     sections.push('');
 
@@ -2345,6 +2480,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateComplexityScores(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({ blueprint_type: 'analysis_complexity' }));
     sections.push(MarkdownFormatter.formatHeading('Entity Complexity Scores', 1));
     sections.push('');
 
@@ -2406,6 +2542,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generatePerformanceRisks(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({ blueprint_type: 'analysis_performance' }));
     sections.push(MarkdownFormatter.formatHeading('Performance Risks', 1));
     sections.push('');
 
@@ -2466,6 +2603,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateMigrationRecommendations(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({ blueprint_type: 'analysis_migration' }));
     sections.push(MarkdownFormatter.formatHeading('Migration Recommendations', 1));
     sections.push('');
 
@@ -2665,6 +2803,15 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   }
 
   /**
+   * Extract publisher prefix from schema name (e.g. "new_Account" -> "new").
+   * Used to populate the `publisher_prefix` frontmatter field on entity files.
+   */
+  private extractPublisherPrefix(schemaName: string): string {
+    const match = schemaName.match(/^([a-z]+)_/i);
+    return match ? match[1] : '';
+  }
+
+  /**
    * Format complexity badge
    */
   private formatComplexityBadge(complexity: 'Low' | 'Medium' | 'High'): string {
@@ -2748,6 +2895,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateSecurityOverview(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'security_overview',
+      security_role_count: result.securityRoles?.length ?? 0,
+      field_security_profile_count: result.fieldSecurityProfiles?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Security Overview', 1));
     sections.push('');
     sections.push('This document provides an overview of security roles and field security profiles in the solution.');
@@ -2840,6 +2992,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateSecurityRoleDetail(role: import('../discovery/SecurityRoleDiscovery.js').SecurityRoleDetail): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'security_role',
+      role_name: role.name,
+    }));
     sections.push(MarkdownFormatter.formatHeading(`Security Role: ${role.name}`, 1));
     sections.push('');
 
@@ -2924,6 +3080,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateFieldSecurityProfiles(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'security_field_security_profiles',
+      profile_count: result.fieldSecurityProfiles?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Field Security Profiles', 1));
     sections.push('');
     sections.push('Field security profiles control who can read, create, or update specific secured fields.');
@@ -2959,6 +3119,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAttributeMaskingRules(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'security_attribute_masking',
+      rule_count: result.attributeMaskingRules?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Attribute Masking Rules', 1));
     sections.push('');
     sections.push('Attribute masking rules control how sensitive data is masked when displayed to users without appropriate permissions.');
@@ -3000,6 +3164,10 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateColumnSecurityProfiles(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'security_column_security',
+      profile_count: result.columnSecurityProfiles?.length ?? 0,
+    }));
     sections.push(MarkdownFormatter.formatHeading('Column Security Profiles', 1));
     sections.push('');
     sections.push('Column security profiles define which users can access specific secured columns across entities.');
@@ -3047,6 +3215,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllCanvasApps(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'canvas_app',
+      item_count: result.canvasApps.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Canvas Apps', 1));
     sections.push('');
     sections.push(`**Total Canvas Apps:** ${result.summary.totalCanvasApps}`);
@@ -3077,6 +3250,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllCustomPages(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'custom_page',
+      item_count: result.customPages.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Custom Pages', 1));
     sections.push('');
     sections.push(`**Total Custom Pages:** ${result.summary.totalCustomPages}`);
@@ -3107,6 +3285,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllModelDrivenApps(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'model_driven_app',
+      item_count: result.modelDrivenApps.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Model-Driven Apps', 1));
     sections.push('');
     sections.push(`**Total Model-Driven Apps:** ${result.summary.totalModelDrivenApps}`);
@@ -3138,6 +3321,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllPcfControls(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'pcf_control',
+      item_count: result.pcfControls.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All PCF Controls', 1));
     sections.push('');
     sections.push(`**Total PCF Controls:** ${result.summary.totalPcfControls}`);
@@ -3170,6 +3358,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllServiceEndpoints(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'service_endpoint',
+      item_count: result.serviceEndpoints.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Service Endpoints', 1));
     sections.push('');
     sections.push(`**Total Service Endpoints:** ${result.summary.totalServiceEndpoints}`);
@@ -3201,6 +3394,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateAllCopilotAgents(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'copilot_agent',
+      item_count: result.copilotAgents.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Copilot Agents', 1));
     sections.push('');
     sections.push(`**Total Copilot Agents:** ${result.summary.totalCopilotAgents}`);
@@ -3233,6 +3431,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllViews(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'view',
+      item_count: result.views.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Views', 1));
     sections.push('');
     sections.push(`**Total Views:** ${result.summary.totalViews}`);
@@ -3260,6 +3463,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllCharts(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'chart',
+      item_count: result.charts.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Charts', 1));
     sections.push('');
     sections.push(`**Total Charts:** ${result.summary.totalCharts}`);
@@ -3286,6 +3494,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllReports(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'report',
+      item_count: result.reports.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Reports', 1));
     sections.push('');
     sections.push(`**Total Reports:** ${result.summary.totalReports}`);
@@ -3312,6 +3525,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllSiteMaps(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'site_map',
+      item_count: result.siteMaps.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Site Maps', 1));
     sections.push('');
     sections.push(`**Total Site Maps:** ${result.summary.totalSiteMaps}`);
@@ -3338,6 +3556,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllSlaDefinitions(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'sla_definition',
+      item_count: result.slaDefinitions.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All SLA Definitions', 1));
     sections.push('');
     sections.push(`**Total SLA Definitions:** ${result.summary.totalSlaDefinitions}`);
@@ -3367,6 +3590,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllDuplicateDetectionRules(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'duplicate_detection_rule',
+      item_count: result.duplicateDetectionRules.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Duplicate Detection Rules', 1));
     sections.push('');
     sections.push(`**Total Duplicate Detection Rules:** ${result.summary.totalDuplicateDetectionRules}`);
@@ -3394,6 +3622,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllDialogs(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'dialog',
+      item_count: result.dialogs.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Dialogs (Deprecated)', 1));
     sections.push('');
     sections.push(`**Total Dialogs:** ${result.summary.totalDialogs}`);
@@ -3424,6 +3657,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllAiModels(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'ai_model',
+      item_count: result.aiModels.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All AI Models', 1));
     sections.push('');
     sections.push(`**Total AI Models:** ${result.summary.totalAiModels}`);
@@ -3453,6 +3691,11 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
    */
   private generateAllVirtualTableDataSources(result: BlueprintResult): string {
     const sections: string[] = [];
+    sections.push(MarkdownFormatter.formatFrontmatter({
+      blueprint_type: 'component_summary',
+      component_type: 'virtual_table_data_source',
+      item_count: result.virtualTableDataSources.length,
+    }));
     sections.push(MarkdownFormatter.formatHeading('All Virtual Table Data Sources', 1));
     sections.push('');
     sections.push(`**Total Virtual Table Data Sources:** ${result.summary.totalVirtualTableDataSources}`);
@@ -3480,6 +3723,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private generateSharedComponentsSummary(result: BlueprintResult): string {
     const sections: string[] = [];
 
+    sections.push(MarkdownFormatter.formatFrontmatter({ blueprint_type: 'summary_shared_components' }));
     sections.push(MarkdownFormatter.formatHeading('Shared Components', 1));
     sections.push('');
     sections.push('Components that appear in two or more solutions.');

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -54,6 +54,7 @@ import {
   groupCustomAPIsByBinding,
 } from '../utils/grouping.js';
 import { calculateComplexityScore } from '../utils/complexity.js';
+import { extractPublisherPrefix } from '../utils/entityName.js';
 import type { IReporter } from './IReporter.js';
 
 export class MarkdownReporter implements IReporter<MarkdownExport> {
@@ -1784,7 +1785,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
       logical_name: meta.LogicalName,
       display_name: displayName,
       schema_name: meta.SchemaName,
-      publisher_prefix: this.extractPublisherPrefix(meta.SchemaName),
+      publisher_prefix: extractPublisherPrefix(meta.SchemaName),
       is_custom: !!meta.IsCustomEntity,
       is_managed: !!meta.IsManaged,
       complexity: complexityScore.level,
@@ -2810,15 +2811,6 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
   private getEntityBpfs(entityLogicalName: string, result: BlueprintResult): BusinessProcessFlow[] {
     const bpfs = result.businessProcessFlowsByEntity.get(entityLogicalName) || [];
     return bpfs;
-  }
-
-  /**
-   * Extract publisher prefix from schema name (e.g. "new_Account" -> "new").
-   * Used to populate the `publisher_prefix` frontmatter field on entity files.
-   */
-  private extractPublisherPrefix(schemaName: string): string {
-    const match = schemaName.match(/^([a-z]+)_/i);
-    return match ? match[1] : '';
   }
 
   /**

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1800,7 +1800,12 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     // Entity description
     const entityDescription = meta.Description?.UserLocalizedLabel?.Label;
     if (entityDescription && entityDescription.trim()) {
-      sections.push(`> ${entityDescription}`);
+      sections.push(
+        entityDescription
+          .split(/\r?\n/)
+          .map(l => `> ${l}`)
+          .join('\n')
+      );
       sections.push('');
     }
 

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1059,7 +1059,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
       // Detail section for each API
       for (const api of apis) {
         sections.push(MarkdownFormatter.formatHeading(`${api.uniqueName}`, 3));
-        if (api.description) sections.push(`> ${api.description}`);
+        if (api.description) sections.push(MarkdownFormatter.formatBlockquote(api.description));
         sections.push('');
         if (api.requestParameters.length > 0) {
           sections.push('**Request Parameters**');
@@ -1292,7 +1292,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
       for (const bpf of bpfs) {
         sections.push(MarkdownFormatter.formatHeading(bpf.name, 3));
         if (bpf.description) {
-          sections.push(`> ${bpf.description}`);
+          sections.push(MarkdownFormatter.formatBlockquote(bpf.description));
           sections.push('');
         }
         if (bpf.definition.stages.length > 0) {

--- a/src/core/reporters/MarkdownReporter.ts
+++ b/src/core/reporters/MarkdownReporter.ts
@@ -1801,12 +1801,7 @@ export class MarkdownReporter implements IReporter<MarkdownExport> {
     // Entity description
     const entityDescription = meta.Description?.UserLocalizedLabel?.Label;
     if (entityDescription && entityDescription.trim()) {
-      sections.push(
-        entityDescription
-          .split(/\r?\n/)
-          .map(l => `> ${l}`)
-          .join('\n')
-      );
+      sections.push(MarkdownFormatter.formatBlockquote(entityDescription));
       sections.push('');
     }
 

--- a/src/core/reporters/markdown/MarkdownFormatter.ts
+++ b/src/core/reporters/markdown/MarkdownFormatter.ts
@@ -233,7 +233,17 @@ export class MarkdownFormatter {
 
       if (Array.isArray(value)) {
         if (value.length === 0) continue;
-        lines.push(`${key}: [${value.join(', ')}]`);
+        const escapeItem = (item: string): string => {
+          if (/[:#,\n\r]/.test(item)) {
+            return `"${item
+              .replace(/\\/g, '\\\\')
+              .replace(/"/g, '\\"')
+              .replace(/\n/g, '\\n')
+              .replace(/\r/g, '\\r')}"`;
+          }
+          return item;
+        };
+        lines.push(`${key}: [${value.map(escapeItem).join(', ')}]`);
         continue;
       }
 
@@ -244,8 +254,17 @@ export class MarkdownFormatter {
 
       const str = String(value);
       if (str.trim() === '') continue;
-      const needsQuotes = /[:#]/.test(str);
-      lines.push(`${key}: ${needsQuotes ? `"${str.replace(/"/g, '\\"')}"` : str}`);
+      const needsQuotes = /[:#\n\r]/.test(str);
+      if (needsQuotes) {
+        const escaped = str
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, '\\n')
+          .replace(/\r/g, '\\r');
+        lines.push(`${key}: "${escaped}"`);
+      } else {
+        lines.push(`${key}: ${str}`);
+      }
     }
 
     lines.push('---');

--- a/src/core/reporters/markdown/MarkdownFormatter.ts
+++ b/src/core/reporters/markdown/MarkdownFormatter.ts
@@ -244,19 +244,24 @@ export class MarkdownFormatter {
       if (value === null || value === undefined) continue;
 
       if (Array.isArray(value)) {
-        if (value.length === 0) continue;
-        const escapeItem = (item: string): string => {
-          const itemIsLiteral = /^(true|false|yes|no|on|off|null|~|-?\d+(\.\d+)?)$/i.test(item);
-          if (/[:#,\n\r[\]{}]/.test(item) || itemIsLiteral) {
-            return `"${item
+        const escapeItem = (item: unknown): string | null => {
+          if (item === null || item === undefined) return null;
+          if (typeof item === 'boolean' || typeof item === 'number') return String(item);
+          const str = typeof item === 'string' ? item : String(item);
+          if (str.trim() === '') return null;
+          const itemIsLiteral = /^(true|false|yes|no|on|off|null|~|-?\d+(\.\d+)?)$/i.test(str);
+          if (/[:#,\n\r[\]{}]/.test(str) || itemIsLiteral) {
+            return `"${str
               .replace(/\\/g, '\\\\')
               .replace(/"/g, '\\"')
               .replace(/\n/g, '\\n')
               .replace(/\r/g, '\\r')}"`;
           }
-          return item;
+          return str;
         };
-        lines.push(`${key}: [${value.map(escapeItem).join(', ')}]`);
+        const items = value.map(escapeItem).filter((s): s is string => s !== null);
+        if (items.length === 0) continue;
+        lines.push(`${key}: [${items.join(', ')}]`);
         continue;
       }
 

--- a/src/core/reporters/markdown/MarkdownFormatter.ts
+++ b/src/core/reporters/markdown/MarkdownFormatter.ts
@@ -234,7 +234,7 @@ export class MarkdownFormatter {
       if (Array.isArray(value)) {
         if (value.length === 0) continue;
         const escapeItem = (item: string): string => {
-          if (/[:#,\n\r]/.test(item)) {
+          if (/[:#,\n\r[\]{}]/.test(item)) {
             return `"${item
               .replace(/\\/g, '\\\\')
               .replace(/"/g, '\\"')

--- a/src/core/reporters/markdown/MarkdownFormatter.ts
+++ b/src/core/reporters/markdown/MarkdownFormatter.ts
@@ -203,6 +203,56 @@ export class MarkdownFormatter {
   }
 
   /**
+   * Generate a YAML frontmatter block for AI-agent-friendly markdown files.
+   * @param fields - snake_case key/value pairs. null/undefined/empty-string/empty-array
+   *   values are skipped. Arrays are rendered inline on one line. Strings are quoted
+   *   only when they contain `:` or `#`. Booleans and numbers are unquoted.
+   * @returns Frontmatter block (`--- ... ---`) followed by a single trailing newline,
+   *   so a blank line separates it from the next pushed section when joined with `\n`.
+   *
+   * @example
+   * ```typescript
+   * MarkdownFormatter.formatFrontmatter({
+   *   blueprint_type: 'entity_overview',
+   *   field_count: 12,
+   *   solution_names: ['Contoso Core', 'Contoso Sales'],
+   * });
+   * // ---
+   * // blueprint_type: entity_overview
+   * // field_count: 12
+   * // solution_names: [Contoso Core, Contoso Sales]
+   * // ---
+   * //
+   * ```
+   */
+  static formatFrontmatter(fields: Record<string, unknown>): string {
+    const lines: string[] = ['---'];
+
+    for (const [key, value] of Object.entries(fields)) {
+      if (value === null || value === undefined) continue;
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) continue;
+        lines.push(`${key}: [${value.join(', ')}]`);
+        continue;
+      }
+
+      if (typeof value === 'boolean' || typeof value === 'number') {
+        lines.push(`${key}: ${value}`);
+        continue;
+      }
+
+      const str = String(value);
+      if (str.trim() === '') continue;
+      const needsQuotes = /[:#]/.test(str);
+      lines.push(`${key}: ${needsQuotes ? `"${str.replace(/"/g, '\\"')}"` : str}`);
+    }
+
+    lines.push('---');
+    return lines.join('\n') + '\n';
+  }
+
+  /**
    * Generate ASCII file tree representation
    * @param node - Root file node
    * @returns Formatted file tree string

--- a/src/core/reporters/markdown/MarkdownFormatter.ts
+++ b/src/core/reporters/markdown/MarkdownFormatter.ts
@@ -203,6 +203,18 @@ export class MarkdownFormatter {
   }
 
   /**
+   * Format a multi-line blockquote, ensuring every line gets a `> ` prefix.
+   * @param text - Raw text (may contain embedded newlines from Dataverse free-text fields)
+   * @returns Markdown blockquote string safe to push directly into a sections array
+   */
+  static formatBlockquote(text: string): string {
+    return text
+      .split(/\r?\n/)
+      .map(line => `> ${line}`)
+      .join('\n');
+  }
+
+  /**
    * Generate a YAML frontmatter block for AI-agent-friendly markdown files.
    * @param fields - snake_case key/value pairs. null/undefined/empty-string/empty-array
    *   values are skipped. Arrays are rendered inline on one line. Strings are quoted
@@ -234,7 +246,8 @@ export class MarkdownFormatter {
       if (Array.isArray(value)) {
         if (value.length === 0) continue;
         const escapeItem = (item: string): string => {
-          if (/[:#,\n\r[\]{}]/.test(item)) {
+          const itemIsLiteral = /^(true|false|yes|no|on|off|null|~|-?\d+(\.\d+)?)$/i.test(item);
+          if (/[:#,\n\r[\]{}]/.test(item) || itemIsLiteral) {
             return `"${item
               .replace(/\\/g, '\\\\')
               .replace(/"/g, '\\"')
@@ -254,7 +267,8 @@ export class MarkdownFormatter {
 
       const str = String(value);
       if (str.trim() === '') continue;
-      const needsQuotes = /[:#\n\r]/.test(str);
+      const isYamlLiteral = /^(true|false|yes|no|on|off|null|~|-?\d+(\.\d+)?)$/i.test(str);
+      const needsQuotes = /[:#\n\r]/.test(str) || isYamlLiteral;
       if (needsQuotes) {
         const escaped = str
           .replace(/\\/g, '\\\\')

--- a/src/core/utils/entityName.ts
+++ b/src/core/utils/entityName.ts
@@ -9,3 +9,12 @@ export function resolveEntityName(value: string | null | undefined): string | nu
   if (!trimmed || trimmed.toLowerCase() === 'none') return null;
   return trimmed;
 }
+
+/**
+ * Extracts the publisher prefix from a schema name (e.g. "new_Account" -> "new").
+ * Returns an empty string when no prefix pattern is found.
+ */
+export function extractPublisherPrefix(schemaName: string): string {
+  const match = schemaName.match(/^([a-z]+)_/i);
+  return match ? match[1] : '';
+}


### PR DESCRIPTION
This pull request introduces a major update to the Markdown export functionality, focusing on making the generated files more AI-friendly and standardizing metadata handling. The changes add YAML frontmatter to all exported Markdown files, improve heading structure for better AI and Azure DevOps Wiki compatibility, and consolidate version information imports. There are also technical improvements to code structure and formatting utilities.

**AI-friendly Markdown export and metadata standardization:**

* All generated Markdown files now include a YAML frontmatter block with metadata such as `blueprint_type`, logical/display names, counts, and version, improving machine readability and traceability. (`src/core/reporters/MarkdownReporter.ts`, `CHANGELOG.md`) [[1]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R221-R236) [[2]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R582) [[3]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R671-R675) [[4]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R749-R753) [[5]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R797-R801) [[6]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R906-R910) [[7]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R960-R964) [[8]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1023-R1027) [[9]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1101-R1105) [[10]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1148-R1152) [[11]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1183-R1187) [[12]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1220-R1224) [[13]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1256-R1260) [[14]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1321-R1324) [[15]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1372-R1376) [[16]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22)
* The cross-entity automation trace replaces `<details>`/`<summary>` HTML blocks with flat `###` headings, ensuring all content is visible to AI agents and renders expanded in Azure DevOps Wiki. (`CHANGELOG.md`, `src/core/reporters/MarkdownReporter.ts`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22) [[2]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R1372-R1376)
* Entity and API descriptions are now formatted as proper Markdown blockquotes for better multi-line support and AI parsing. (`src/core/reporters/MarkdownReporter.ts`) [[1]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168L1011-R1062) [[2]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168L1219-R1295)

**Technical/codebase improvements:**

* Added new static helpers to `MarkdownFormatter` for generating YAML frontmatter and blockquotes, with robust escaping for YAML special characters and multi-line text. (`CHANGELOG.md`, `src/core/reporters/MarkdownReporter.ts`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22) [[2]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R221-R236) [[3]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168L1011-R1062) [[4]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168L1219-R1295)
* The version import pattern is unified: both `MarkdownReporter.ts` and `JsonReporter.ts` now import `version` from `package.json`, eliminating a previous manual update step and reducing release blockers. (`src/core/reporters/MarkdownReporter.ts`, `.claude/memory/learnings.md`, `.claude/memory/project.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R45) [[2]](diffhunk://#diff-cfae7f9cd267a94732c8d94df507e3c99da3a5a6c528ea23786eed1a7be52168R57-R62) [[3]](diffhunk://#diff-692742d25d2b699531a42b9a841f52655fe7788a8f54205101f65f2e26ffc9a4L173-R187) [[4]](diffhunk://#diff-ea38ff721ee32a9e2630242b6623f657fa8d6dc6423a18ef00d609a0a3e2820cL3-R3) [[5]](diffhunk://#diff-ea38ff721ee32a9e2630242b6623f657fa8d6dc6423a18ef00d609a0a3e2820cL21-R32) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R22)

**Documentation and project memory updates:**

* Project documentation and memory files are updated to reflect the new release, the in-progress branch, and the resolved versioning rule (now requiring version consistency across four files, not five). (`.claude/memory/learnings.md`, `.claude/memory/project.md`) [[1]](diffhunk://#diff-692742d25d2b699531a42b9a841f52655fe7788a8f54205101f65f2e26ffc9a4L173-R187) [[2]](diffhunk://#diff-ea38ff721ee32a9e2630242b6623f657fa8d6dc6423a18ef00d609a0a3e2820cL3-R3) [[3]](diffhunk://#diff-ea38ff721ee32a9e2630242b6623f657fa8d6dc6423a18ef00d609a0a3e2820cL21-R32)

These changes collectively improve the maintainability, AI compatibility, and reliability of the Markdown export process.